### PR TITLE
change Gitter references to Slack

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -54,7 +54,7 @@ threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies in project spaces (e.g. the wiki, pull requests, any documentation and code) and in public spaces (such as the [Gitter community](https://gitter.im/book-project-community/)) when an individual is representing the project or its community. 
+This Code of Conduct applies in project spaces (e.g. the wiki, pull requests, any documentation and code) and in public spaces (such as our [Slack workspace](https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw)) when an individual is representing the project or its community. 
 
 ## Enforcement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,11 +30,11 @@ By contributing to this project, you are expected to adhere to the [Book Project
 
 All questions, suggestions and feedback are both welcome and encouraged. 
 
-Questions and feedback should be discussed over [Gitter](https://gitter.im/book-project-community). This allows others to benefit from seeing the answers, too.
+Questions and feedback should be discussed over [Slack](https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw). This allows others to benefit from seeing the answers, too.
 
 For suggestions, please vote on, or add to, the existing relevant issue. If no such issue exists, feel free to open a new issue.
 
-If in doubt, talk to us over [Gitter](https://gitter.im/book-project-community)!
+If in doubt, talk to us over [Slack](https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw)!
 
 ## Before making changes
 
@@ -121,12 +121,12 @@ If you no longer wish to work an issue, that's fine. All we ask is that you let 
 
 Where possible, please let us know as soon as possible if you no longer wish to work on an issue. 
 
-Please also consider that you're finding something difficult on the issue you're assigned to, we're here to help on [Gitter](https://gitter.im/book-project-community/community).
+Please also consider that you're finding something difficult on the issue you're assigned to, we're here to help on [Slack](https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw).
 
 ## Ways to contribute
 
 - Code: adding new features, fixing bugs and general refactoring to name a few
-  - Code reviews: either offering to review a pull request on Gitter or if you see a pull request and think the code could be improved, feel free to offer suggestions on how to do so. This can help improve our code quality and is much appreciated!
+  - Code reviews: either offering to review a pull request on Slack or if you see a pull request and think the code could be improved, feel free to offer suggestions on how to do so. This can help improve our code quality and is much appreciated!
      - Before reviewing code, please ensure you are familiar with and understand our [code reviews document](https://github.com/knjk04/book-project/blob/master/.github/CODE_REVIEWS.md)
   - Issues and pull requests labelled with [needs-repro](https://github.com/knjk04/book-project/labels/needs-repro) have yet to be reproduced. If you're able to reproduce it, letting us know would help a lot
   - Our test coverage is low, so we need a lot more tests, particularly the areas that are undertested or not covered at all
@@ -137,4 +137,4 @@ Please also consider that you're finding something difficult on the issue you're
 
 - Feedback: we're eager to find new ways to improve, so please do let us know!
 
-- Translations: it would be good if we could support multiple languages. If you're able to help with this, feel free to get in touch with us over [Gitter](https://gitter.im/book-project-community).
+- Translations: it would be good if we could support multiple languages. If you're able to help with this, feel free to get in touch with us over [Slack](https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw).

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
   <a href="https://codecov.io/gh/Project-Books/book-project">
     <img src="https://codecov.io/gh/Project-Books/book-project/branch/master/graph/badge.svg" alt="Code coverage"/>
   </a>
-  <a href="https://gitter.im/book-project-community/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge">
-    <img src="https://badges.gitter.im/book-project-community/community.svg" alt="Gitter" />
+  <a href="https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw">
+    <img src="https://img.shields.io/badge/chat%20on-slack-%233f0e40" alt="Slack" />
   </a>
   <a href="https://app.codacy.com/manual/knjk04/book-project?utm_source=github.com&utm_medium=referral&utm_content=knjk04/book-project&utm_campaign=Badge_Grade_Dashboard">
     <img src="https://api.codacy.com/project/badge/Grade/595ed2c299d7429e9938894c385b9cab" alt="Code quality" />
@@ -105,7 +105,7 @@ For more information, such as a roadmap and the underlying principles of the pro
 
 ### Help
 
-If you need help with anything, we'll be happy to help you in our [Gitter Channel](https://gitter.im/book-project-community/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge).
+If you need help with anything, we'll be happy to help you in our [Slack workspace](https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw).
 
 ## Acknowledgements
 

--- a/docs/CODE_REVIEWS.md
+++ b/docs/CODE_REVIEWS.md
@@ -63,7 +63,7 @@ try to get back to them within seven days.
 
 For high priority bug fixes, we would recommend the PR as soon as possible as it is important that add patches as soon as possible. 
 
-If you are do not have a sufficient amount of time to review a PR, please inform the project maintainer (e.g. over Gitter) so that they or someone else can review it.
+If you are do not have a sufficient amount of time to review a PR, please inform the project maintainer (e.g. over Slack) so that they or someone else can review it.
 
 ### Providing updates
 

--- a/docs/TEAM.md
+++ b/docs/TEAM.md
@@ -10,13 +10,13 @@ In particular, all maintainers must be welcoming and inclusive to all at all tim
 ### Project owner
 
 Karan ([@knjk04](https://github.com/knjk04)) first started this project and is the owner of the repository. As the project owner, this role also includes the maintainer role. Karan is active in committing to the project, reviewing code and helping others on the project over
-Gitter.
+Slack.
 
 Karan has the final say on decisions and is in responsible for the overall direction of the project. However, Karan is always open to new ideas and thoughts. If you think
 something could be done better, speak up! While we cannot guarantee that we will take your suggestion forward, we can promise that your feedback is valuable and that you
 will be responded to, regardless of whether we take up your suggestion. If we don't take your suggestion forward, we'll also let you know why.
 
-Should you have any concerns about any of the maintainers, Karan is the person to speak to. You can message him privately on Gitter.
+Should you have any concerns about any of the maintainers, Karan is the person to speak to. You can message him privately on Slack.
 
 ### Maintainers
 
@@ -26,7 +26,7 @@ Maintainers have made regular and several significant contributions to the proje
 Maintainers could have made important contributions in, for example, design or documentation. 
 
 A maintainer may have a particular area of expertise. If they do, it will be listed here. You can then reach out to them should you need any help. We encourage the 
-communication to happen over our public Gitter channel rather than privately so that others can also benefit from the responses. It can also help to settle disputes
+communication to happen over our public Slack #book-project channel rather than privately so that others can also benefit from the responses. It can also help to settle disputes
 if we can all see the exchange(s). 
 
 While everyone can help shape the direction of the project, this is particularly true of maintainers, as the owner and other maintainers may lean on each other.
@@ -46,7 +46,7 @@ In addition to regularly committing, a maintainer is expected to review pull req
 In general, we try to review pull requests within seven days (regular days, not working days) of having received them. If this is not feasible for you, please discuss
 this with the owner as we are somewhat flexible on this.
 
-Lastly, we have an active Gitter community room where we can provide help to committers. We expect maintainers to be active here to help others. We don't expect
+Lastly, we have an active Slack workspace (formerly a Gitter community) where we can provide help to committers. We expect maintainers to be active here to help others. We don't expect
 our maintainers always to be online, but to be responsive to messages directed towards them and undirected messages that they can help with. As a rule of thumb, we would
 expect maintainers to reply within seven days.
 
@@ -58,9 +58,9 @@ We appreciate this is a large commitment to make, so we highly value the time an
 
 If Karan believes you are already operating at our maintainer standard, he may contact you to ask whether you would like to become a maintainer. If this is the case, we we still follow our process of agreeing on the details on how frequently you are available to help.
 
-If you were not approached and would like to become a maintainer, feel free to message Karan ([@knjk04](https://github.com/knjk04)) on Gitter. This can be done either privately or on the Gitter group chat. If we say no, we will
+If you were not approached and would like to become a maintainer, feel free to message Karan ([@knjk04](https://github.com/knjk04)) on Slack. This can be done either privately or on the Slack #book-project channel. If we say no, we will
 be constructive by telling you what you would need to do to get there (e.g. contribute for longer to gain further trust). Please do not feel disheartened
-if we say no. Think of it as 'not yet' rather than 'never'. If you ask Karan publicly on Gitter, the assumption is that you are happy for a public response.
+if we say no. Think of it as 'not yet' rather than 'never'. If you ask Karan publicly on Slack, the assumption is that you are happy for a public response.
 
 #### Removing a maintainer
 

--- a/docs/leadership/becoming-a-maintainer-template.md
+++ b/docs/leadership/becoming-a-maintainer-template.md
@@ -14,4 +14,4 @@ availability changes, that's fine. The important thing is to let us know so that
 
 4. Are you able to help fix failing builds or when we have high-priority bugs to fix regularly? If so, how often (e.g. weekly, fortnightly)?
 
-5. Are you able to help others and respond to others on Gitter (we aim to respond to messages within at most seven days)?
+5. Are you able to help others and respond to others on our Slack workspace (we aim to respond to messages within at most seven days)?


### PR DESCRIPTION
## Summary of change

Replaces Gitter references and links to Slack.

## Related issue

#327 

## Pull request checklist

Please ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [X] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [X] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [X] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

If in doubt, get in touch with us via our [Gitter room](https://gitter.im/book-project-community/community)
