### PR TITLE
fix the save button initial state in the add shelf form and related issues

### DIFF
--- a/src/main/java/com/karankumar/bookproject/ui/shelf/CustomShelfForm.java
+++ b/src/main/java/com/karankumar/bookproject/ui/shelf/CustomShelfForm.java
@@ -17,6 +17,7 @@
 
 package com.karankumar.bookproject.ui.shelf;
 
+import com.helger.commons.annotation.VisibleForTesting;
 import com.karankumar.bookproject.backend.entity.CustomShelf;
 import com.karankumar.bookproject.backend.service.CustomShelfService;
 import com.karankumar.bookproject.backend.service.PredefinedShelfService;
@@ -36,6 +37,7 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.BeanValidationBinder;
 import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
 
@@ -49,7 +51,11 @@ public class CustomShelfForm extends VerticalLayout {
     private final PredefinedShelfService predefinedShelfService;
 
     private Binder<CustomShelf> binder = new BeanValidationBinder<>(CustomShelf.class);
-    private final TextField shelfNameField = new TextField();
+
+    @VisibleForTesting
+    final TextField shelfNameField = new TextField();
+    @VisibleForTesting
+    final Button saveButton = new Button();
 
     public CustomShelfForm(CustomShelfService customShelfService,
                            PredefinedShelfService predefinedShelfService) {
@@ -57,6 +63,7 @@ public class CustomShelfForm extends VerticalLayout {
         dialog = new Dialog();
         dialog.add(new H3("Add custom shelf"), formLayout);
         dialog.setCloseOnOutsideClick(true);
+        dialog.addDialogCloseActionListener(dialogCloseActionEvent -> closeForm());
         add(dialog);
 
         this.customShelfService = customShelfService;
@@ -100,16 +107,18 @@ public class CustomShelfForm extends VerticalLayout {
         shelfNameField.setClearButtonVisible(true);
         shelfNameField.setPlaceholder("Enter shelf name");
         shelfNameField.addClassName("shelfFormInputField");
+        shelfNameField.setValueChangeMode(ValueChangeMode.EAGER);
+        shelfNameField.addValueChangeListener(event -> saveButton.setEnabled(binder.isValid()));
     }
 
     private Button createSaveButton() {
-        Button save = new Button();
-        save.setText("Save");
-        save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-        save.setDisableOnClick(true);
-        save.addClassName("shelfFormSaveButton");
-        save.addClickListener(event -> validateOnSave());
-        return save;
+        saveButton.setText("Save");
+        saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        saveButton.setDisableOnClick(true);
+        saveButton.addClassName("shelfFormSaveButton");
+        saveButton.addClickListener(event -> validateOnSave());
+        saveButton.setEnabled(binder.isValid());
+        return saveButton;
     }
 
     private void validateOnSave() {
@@ -129,7 +138,10 @@ public class CustomShelfForm extends VerticalLayout {
         binder.setBean(new CustomShelf(shelfNameField.getValue()));
     }
 
-    private void closeForm() {
+    @VisibleForTesting
+    void closeForm() {
+        shelfNameField.clear();
+        shelfNameField.setInvalid(false);
         dialog.close();
     }
 

--- a/src/test/java/com/karankumar/bookproject/ui/shelf/CustomShelfFormTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/shelf/CustomShelfFormTest.java
@@ -1,0 +1,172 @@
+/*
+    The book project lets a user keep track of different books they would like to read, are currently
+    reading, have read or did not finish.
+    Copyright (C) 2020  Karan Kumar
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the
+    GNU General Public License as published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+    PURPOSE.  See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along with this program.
+    If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.karankumar.bookproject.ui.shelf;
+
+import com.github.mvysny.kaributesting.v10.MockVaadin;
+import com.github.mvysny.kaributesting.v10.Routes;
+import com.karankumar.bookproject.annotations.IntegrationTest;
+import com.karankumar.bookproject.backend.entity.PredefinedShelf;
+import com.karankumar.bookproject.backend.service.CustomShelfService;
+import com.karankumar.bookproject.backend.service.PredefinedShelfService;
+import com.karankumar.bookproject.ui.MockSpringServlet;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.spring.SpringServlet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@IntegrationTest
+@WebAppConfiguration
+class CustomShelfFormTest {
+
+    private static Routes routes;
+
+    @Autowired private ApplicationContext ctx;
+
+    private CustomShelfForm customShelfForm;
+
+    @BeforeAll
+    public static void discoverRoutes() {
+        routes = new Routes().autoDiscoverViews("com.karankumar.bookproject.ui");
+    }
+
+    @BeforeEach
+    public void setup(@Autowired PredefinedShelfService predefinedShelfService,
+                      @Autowired CustomShelfService customShelfService) {
+        final SpringServlet servlet = new MockSpringServlet(routes, ctx);
+        MockVaadin.setup(UI::new, servlet);
+
+        customShelfForm = new CustomShelfForm(customShelfService, predefinedShelfService);
+    }
+
+    @Test
+    void saveButtonShouldBeInitiallyGreyedOut () {
+        // given
+        // customShelfForm
+
+        // when
+        userOpenDialog();
+
+        // then
+        formIsInInitialState();
+    }
+
+    private void userOpenDialog() {
+        customShelfForm.addShelf();
+    }
+
+    private void formIsInInitialState() {
+        assertThat(customShelfForm.shelfNameField.getValue()).isEmpty();
+        assertFalse(customShelfForm.shelfNameField.isInvalid());
+        assertFalse(customShelfForm.saveButton.isEnabled());
+    }
+
+    @Test
+    void saveButtonShouldBeGreyedOutWithExistingShelfName () {
+        // given
+        // customShelfForm
+
+        // when
+        shelfNameIsLikeOneAlreadyInUse();
+
+        // then
+        formsIsInErrorState();
+    }
+
+    private void shelfNameIsLikeOneAlreadyInUse() {
+        customShelfForm.shelfNameField.setValue(PredefinedShelf.ShelfName.TO_READ.toString());
+    }
+
+    private void formsIsInErrorState() {
+        assertTrue(customShelfForm.shelfNameField.isInvalid());
+        assertFalse(customShelfForm.saveButton.isEnabled());
+    }
+
+    @Test
+    void saveButtonShouldBeEnabledWithNonExistingShelfName () {
+        // given
+        // customShelfForm
+
+        // when
+        shelfNameIsNotLikeOneAlreadyInUse();
+
+        // then
+        formIsInValidState();
+    }
+
+    private void shelfNameIsNotLikeOneAlreadyInUse() {
+        customShelfForm.shelfNameField.setValue("NonExistingShelfName");
+    }
+
+    private void formIsInValidState() {
+        assertThat(customShelfForm.shelfNameField.getValue()).isNotEmpty();
+        assertFalse(customShelfForm.shelfNameField.isInvalid());
+        assertTrue(customShelfForm.saveButton.isEnabled());
+    }
+
+    @Test
+    void savingAndReopeningFormShouldClearTextfield () {
+        // given
+        // customShelfForm
+
+        // when
+        userOpenDialog();
+        userCloseSavingAShelf();
+        userOpenDialog();
+
+        // then
+        formIsInInitialState();
+    }
+
+    private void userCloseSavingAShelf() {
+        customShelfForm.shelfNameField.setValue("Test");
+        customShelfForm.saveButton.click();
+    }
+
+    @Test
+    void closingWithoutSavingAndReopeningFormShouldClearTextField () {
+        // given
+        // customShelfForm
+
+        // when
+        userOpenDialog();
+        userCloseWithoutSavingAShelf();
+        userOpenDialog();
+
+        // then
+        formIsInInitialState();
+    }
+
+    private void userCloseWithoutSavingAShelf() {
+        customShelfForm.shelfNameField.setValue("Test");
+        customShelfForm.closeForm();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockVaadin.tearDown();
+    }
+}


### PR DESCRIPTION
## Summary of change

I disabled the save button when the form is open for the 1st time; I also cleared the text field and save button status on dialog closing either when saving a new shelf or when cancelling the form.

## Related issue

#255

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

If in doubt, get in touch with us via our [Slack workspace](https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw)
