### PR TITLE
adds 'Appearance' and 'My books' as subheading in settings page

### DIFF
--- a/src/main/java/com/karankumar/bookproject/ui/settings/SettingsView.java
+++ b/src/main/java/com/karankumar/bookproject/ui/settings/SettingsView.java
@@ -20,11 +20,13 @@ package com.karankumar.bookproject.ui.settings;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.karankumar.bookproject.backend.service.BookService;
 import com.karankumar.bookproject.ui.MainView;
-import com.karankumar.bookproject.ui.components.toggle.SwitchToggle;
 import com.karankumar.bookproject.ui.components.dialog.ResetShelvesDialog;
+import com.karankumar.bookproject.ui.components.toggle.SwitchToggle;
+import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
@@ -47,10 +49,16 @@ import java.util.logging.Level;
 public class SettingsView extends HorizontalLayout {
 
     private static final String ENABLE_DARK_MODE = "Enable dark mode";
+    private static final String APPEARANCE = "Appearance:";
+    private static final String MYBOOKS = "My books:";
     private static final String DISABLE_DARK_MODE = "Disable dark mode";
     private static final SwitchToggle darkModeToggle;
     private static boolean darkModeOn = false;
     private static final Label darkModeLabel = new Label(ENABLE_DARK_MODE);
+    private static final H3 appearanceH3 = new H3(APPEARANCE);
+    private static final H3 myBooksH3 = new H3(MYBOOKS);
+    private static final HtmlComponent br = new HtmlComponent("br");
+
 
     // Clear Shelves
     private static ResetShelvesDialog resetShelvesDialog;
@@ -97,7 +105,7 @@ public class SettingsView extends HorizontalLayout {
 
         configureExportBooksAnchor();
 
-        VerticalLayout verticalLayout = new VerticalLayout(horizontalLayout, clearShelvesButton, exportBooksAnchor);
+        VerticalLayout verticalLayout = new VerticalLayout(appearanceH3, horizontalLayout, br, myBooksH3, clearShelvesButton, exportBooksAnchor);
 
         verticalLayout.setAlignItems(Alignment.CENTER);
 
@@ -131,9 +139,9 @@ public class SettingsView extends HorizontalLayout {
             final StreamResource resource = new StreamResource("bookExport.json",
                     () -> new ByteArrayInputStream(jsonRepresentationForBooks));
             final StreamRegistration registration = UI.getCurrent()
-                                                    .getSession()
-                                                    .getResourceRegistry()
-                                                    .registerResource(resource);
+                    .getSession()
+                    .getResourceRegistry()
+                    .registerResource(resource);
 
             return registration.getResourceUri().toString();
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/karankumar/bookproject/ui/settings/SettingsView.java
+++ b/src/main/java/com/karankumar/bookproject/ui/settings/SettingsView.java
@@ -50,15 +50,14 @@ public class SettingsView extends HorizontalLayout {
 
     private static final String ENABLE_DARK_MODE = "Enable dark mode";
     private static final String APPEARANCE = "Appearance:";
-    private static final String MYBOOKS = "My books:";
+    private static final String MY_BOOKS = "My books:";
     private static final String DISABLE_DARK_MODE = "Disable dark mode";
     private static final SwitchToggle darkModeToggle;
     private static boolean darkModeOn = false;
     private static final Label darkModeLabel = new Label(ENABLE_DARK_MODE);
-    private static final H3 appearanceH3 = new H3(APPEARANCE);
-    private static final H3 myBooksH3 = new H3(MYBOOKS);
-    private static final HtmlComponent br = new HtmlComponent("br");
-
+    private static final H3 appearanceHeading = new H3(APPEARANCE);
+    private static final H3 myBooksHeading = new H3(MY_BOOKS);
+    private static final HtmlComponent lineBreak = new HtmlComponent("br");
 
     // Clear Shelves
     private static ResetShelvesDialog resetShelvesDialog;
@@ -105,7 +104,14 @@ public class SettingsView extends HorizontalLayout {
 
         configureExportBooksAnchor();
 
-        VerticalLayout verticalLayout = new VerticalLayout(appearanceH3, horizontalLayout, br, myBooksH3, clearShelvesButton, exportBooksAnchor);
+        VerticalLayout verticalLayout = new VerticalLayout(
+                appearanceHeading,
+                horizontalLayout,
+                lineBreak,
+                myBooksHeading,
+                clearShelvesButton,
+                exportBooksAnchor
+        );
 
         verticalLayout.setAlignItems(Alignment.CENTER);
 
@@ -139,9 +145,9 @@ public class SettingsView extends HorizontalLayout {
             final StreamResource resource = new StreamResource("bookExport.json",
                     () -> new ByteArrayInputStream(jsonRepresentationForBooks));
             final StreamRegistration registration = UI.getCurrent()
-                    .getSession()
-                    .getResourceRegistry()
-                    .registerResource(resource);
+                                                    .getSession()
+                                                    .getResourceRegistry()
+                                                    .registerResource(resource);
 
             return registration.getResourceUri().toString();
         } catch (JsonProcessingException e) {


### PR DESCRIPTION
## Summary of change

Add subheadings to separate the different sections:
- An 'Appearance' heading that contains the dark mode toggle
- A 'My books' heading that contains the 'reset shelves' and export button

## Additional context

<img width="526" alt="Screenshot 2020-10-02 at 3 50 29 PM" src="https://user-images.githubusercontent.com/32308441/94913568-1dce6280-04c7-11eb-9dc1-d4c1767e1a18.png">


## Related issue

Closes #373 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

If in doubt, get in touch with us via our [Slack workspace](https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw)
