### PR TITLE
Hide "Most liked book" and "Least liked book" if only one book or fewer present

### DIFF
--- a/src/main/java/com/karankumar/bookproject/backend/statistics/RatingStatistics.java
+++ b/src/main/java/com/karankumar/bookproject/backend/statistics/RatingStatistics.java
@@ -40,7 +40,7 @@ public class RatingStatistics extends Statistics {
      * If there are multiple books with the same highest rating, the first one found will be returned
      */
     public Book findMostLikedBook() {
-        if (readBooksRated.isEmpty()) {
+        if (readBooksRated.size() <= 1) {
             return null;
         }
         readBooksRated.sort(Comparator.comparing(Book::getRating));
@@ -61,7 +61,7 @@ public class RatingStatistics extends Statistics {
      * If there are multiple books with the same lowest rating, the first one found will be returned
      */
     public Book findLeastLikedBook() {
-        if (readBooksRated.isEmpty()) {
+        if (readBooksRated.size() <= 1) {
             return null;
         }
         readBooksRated.sort(Comparator.comparing(Book::getRating));

--- a/src/main/java/com/karankumar/bookproject/backend/statistics/RatingStatistics.java
+++ b/src/main/java/com/karankumar/bookproject/backend/statistics/RatingStatistics.java
@@ -74,7 +74,7 @@ public class RatingStatistics extends Statistics {
      */
     public Double calculateAverageRatingGiven() {
         int numberOfRatings = readBooksRated.size();
-        if (numberOfRatings == 0) {
+        if (numberOfRatings <= 1) {
             return null;
         }
         return (calculateTotalRating() / numberOfRatings);

--- a/src/test/java/com/karankumar/bookproject/ui/statistics/StatisticsViewTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/statistics/StatisticsViewTest.java
@@ -42,6 +42,7 @@ import static com.karankumar.bookproject.ui.statistics.util.StatisticsViewTestUt
 import static com.karankumar.bookproject.ui.statistics.util.StatisticsViewTestUtils.populateDataWithBooksWithoutGenre;
 import static com.karankumar.bookproject.ui.statistics.util.StatisticsViewTestUtils.populateDataWithBooksWithoutPageCount;
 import static com.karankumar.bookproject.ui.statistics.util.StatisticsViewTestUtils.populateDataWithBooksWithoutRatings;
+import static com.karankumar.bookproject.ui.statistics.util.StatisticsViewTestUtils.populateDataWithOnlyOneBook;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -134,6 +135,18 @@ class StatisticsViewTest {
     }
 
     @Test
+    void withOnlyOneBookTheMostLikedAndLeastLikedBookShouldBeAbsent() {
+        // given
+        populateDataWithOnlyOneBook(bookService, predefinedShelfService);
+
+        // when
+        statisticsView = new StatisticsView(predefinedShelfService);
+
+        // then
+        likedBookStatisticsAreAbsent();
+    }
+
+    @Test
     void withoutRatingInformationTheViewShouldShowOtherStatistics() {
         // given
         populateDataWithBooksWithoutRatings(bookService, predefinedShelfService);
@@ -178,6 +191,10 @@ class StatisticsViewTest {
 
     private void genreAndRatingStatisticsAreAbsent() {
         statisticsAreAbsent(MOST_LIKED_GENRE, LEAST_LIKED_GENRE);
+    }
+
+    private void likedBookStatisticsAreAbsent() {
+        statisticsAreAbsent(MOST_LIKED_BOOK, LEAST_LIKED_BOOK);
     }
 
     private void statisticsAreAbsent(StatisticType... statisticTypes) {

--- a/src/test/java/com/karankumar/bookproject/ui/statistics/StatisticsViewTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/statistics/StatisticsViewTest.java
@@ -143,7 +143,7 @@ class StatisticsViewTest {
         statisticsView = new StatisticsView(predefinedShelfService);
 
         // then
-        likedBookStatisticsAreAbsent();
+        ratingStatisticsAreAbsent();
     }
 
     @Test
@@ -191,10 +191,6 @@ class StatisticsViewTest {
 
     private void genreAndRatingStatisticsAreAbsent() {
         statisticsAreAbsent(MOST_LIKED_GENRE, LEAST_LIKED_GENRE);
-    }
-
-    private void likedBookStatisticsAreAbsent() {
-        statisticsAreAbsent(MOST_LIKED_BOOK, LEAST_LIKED_BOOK);
     }
 
     private void statisticsAreAbsent(StatisticType... statisticTypes) {

--- a/src/test/java/com/karankumar/bookproject/ui/statistics/StatisticsViewTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/statistics/StatisticsViewTest.java
@@ -81,7 +81,7 @@ class StatisticsViewTest {
     private void valueIsPresent(StatisticsViewTestUtils.Statistic currentStatistic) {
         assertFalse(currentStatistic instanceof StatisticNotFound);
     }
-    
+
     private void thereAreNotOtherStatistics() {
         assertEquals(StatisticType.values().length, statisticsView.getComponentCount());
     }

--- a/src/test/java/com/karankumar/bookproject/ui/statistics/util/StatisticsViewTestUtils.java
+++ b/src/test/java/com/karankumar/bookproject/ui/statistics/util/StatisticsViewTestUtils.java
@@ -117,26 +117,23 @@ public class StatisticsViewTestUtils {
     }
 
     private static Book createBook(String title, Author author,
-                                   PredefinedShelfService predefinedShelfService, BookGenre genre,
-                                   int numberOfPages, int pagesRead, RatingScale rating) {
+                                   PredefinedShelfService predefinedShelfService) {
         PredefinedShelf readShelf = getReadShelf(predefinedShelfService);
         final var book = new Book(title, author, readShelf);
-        book.setBookGenre(genre);
-        book.setNumberOfPages(numberOfPages);
-        book.setPagesRead(pagesRead);
-        book.setRating(rating);
+        book.setBookGenre(BookGenre.FANTASY);
+        book.setNumberOfPages(2000);
+        book.setPagesRead(1000);
+        book.setRating(RatingScale.EIGHT_POINT_FIVE);
         return book;
     }
 
     private static Book createMobyDickBook(PredefinedShelfService predefinedShelfService) {
         final var author = new Author("Herman", "Melville");
-        return createBook("Moby Dick", author, predefinedShelfService, BookGenre.ADVENTURE, 2000,
-                1000, RatingScale.EIGHT);
+        return createBook("Moby Dick", author, predefinedShelfService);
     }
 
     private static Book createHobbitBook(PredefinedShelfService predefinedShelfService) {
         final var author = new Author("J.R.R", "Tolkien");
-        return createBook("The Hobbit", author, predefinedShelfService, BookGenre.FANTASY, 1999,
-                1110, RatingScale.EIGHT_POINT_FIVE);
+        return createBook("The Hobbit", author, predefinedShelfService);
     }
 }

--- a/src/test/java/com/karankumar/bookproject/ui/statistics/util/StatisticsViewTestUtils.java
+++ b/src/test/java/com/karankumar/bookproject/ui/statistics/util/StatisticsViewTestUtils.java
@@ -77,6 +77,12 @@ public class StatisticsViewTestUtils {
         bookService.save(hobbitBook);
     }
 
+    public static void populateDataWithOnlyOneBook(
+            BookService bookService, PredefinedShelfService predefinedShelfService) {
+        Book mobyDickBook = createMobyDickBook(predefinedShelfService);
+        bookService.save(mobyDickBook);
+    }
+
     public static void populateDataWithBooksWithoutPageCount(
             BookService bookService, PredefinedShelfService predefinedShelfService) {
         Book mobyDickBook = createMobyDickBook(predefinedShelfService);

--- a/src/test/java/com/karankumar/bookproject/ui/statistics/util/StatisticsViewTestUtils.java
+++ b/src/test/java/com/karankumar/bookproject/ui/statistics/util/StatisticsViewTestUtils.java
@@ -65,22 +65,30 @@ public class StatisticsViewTestUtils {
 
     public static void populateDataWithBooks(
             BookService bookService, PredefinedShelfService predefinedShelfService) {
-        Book book = createMobyDickBook(predefinedShelfService);
-        bookService.save(book);
+        Book mobyDickBook = createMobyDickBook(predefinedShelfService);
+        Book hobbitBook = createHobbitBook(predefinedShelfService);
+        bookService.save(mobyDickBook);
+        bookService.save(hobbitBook);
     }
     
     public static void populateDataWithBooksWithoutPageCount(
             BookService bookService, PredefinedShelfService predefinedShelfService) {
-        Book book = createMobyDickBook(predefinedShelfService);
-        book.setNumberOfPages(null);
-        bookService.save(book);
+        Book mobyDickBook = createMobyDickBook(predefinedShelfService);
+        Book hobbitBook = createHobbitBook(predefinedShelfService);
+        mobyDickBook.setNumberOfPages(null);
+        hobbitBook.setNumberOfPages(null);
+        bookService.save(mobyDickBook);
+        bookService.save(hobbitBook);
     }
 
     public static void populateDataWithBooksWithoutGenre(
             BookService bookService, PredefinedShelfService predefinedShelfService) {
-        Book book = createMobyDickBook(predefinedShelfService);
-        book.setBookGenre(null);
-        bookService.save(book);
+        Book mobyDickBook = createMobyDickBook(predefinedShelfService);
+        Book hobbitBook = createHobbitBook(predefinedShelfService);
+        mobyDickBook.setBookGenre(null);
+        hobbitBook.setBookGenre(null);
+        bookService.save(mobyDickBook);
+        bookService.save(hobbitBook);
     }
 
     public static void populateDataWithBooksWithoutRatings(
@@ -103,6 +111,17 @@ public class StatisticsViewTestUtils {
         book.setNumberOfPages(2000);
         book.setPagesRead(1000);
         book.setRating(RatingScale.EIGHT_POINT_FIVE);
+        return book;
+    }
+
+    private static Book createHobbitBook(PredefinedShelfService predefinedShelfService) {
+        PredefinedShelf readShelf = getReadShelf(predefinedShelfService);
+        Author author = new Author("J.R.R", "Tolkien");
+        Book book = new Book("The Hobbit", author, readShelf);
+        book.setBookGenre(BookGenre.FANTASY);
+        book.setNumberOfPages(2000);
+        book.setPagesRead(1000);
+        book.setRating(RatingScale.EIGHT);
         return book;
     }
 }

--- a/src/test/java/com/karankumar/bookproject/ui/statistics/util/StatisticsViewTestUtils.java
+++ b/src/test/java/com/karankumar/bookproject/ui/statistics/util/StatisticsViewTestUtils.java
@@ -18,22 +18,26 @@ import java.util.function.Predicate;
 
 public class StatisticsViewTestUtils {
 
-    private StatisticsViewTestUtils() {}
+    private StatisticsViewTestUtils() {
+    }
 
     @AllArgsConstructor
     public static class Statistic {
         @Getter private final String caption;
         @Getter private final String value;
     }
+
     public static class StatisticNotFound extends Statistic {
         public StatisticNotFound() {
             super("statistic", "not found");
         }
     }
 
-    public static Statistic getStatistic(StatisticsView.StatisticType statisticType, StatisticsView statisticsView) {
+    public static Statistic getStatistic(StatisticsView.StatisticType statisticType,
+                                         StatisticsView statisticsView) {
         try {
-            Element verticalLayoutInDiv = getVerticalLayoutWithStatistic(statisticType, statisticsView);
+            Element verticalLayoutInDiv =
+                    getVerticalLayoutWithStatistic(statisticType, statisticsView);
             // statistic caption is in VL -> H3 -> Text
             String caption = verticalLayoutInDiv.getChild(0)
                                                 .getText();
@@ -45,22 +49,24 @@ public class StatisticsViewTestUtils {
         }
     }
 
-    private static Element getVerticalLayoutWithStatistic(StatisticsView.StatisticType statisticType, StatisticsView statisticsView) {
+    private static Element getVerticalLayoutWithStatistic(
+            StatisticsView.StatisticType statisticType, StatisticsView statisticsView) {
         var divContainingStatistic = statisticsView.getChildren()
-                                                            .filter(textWithinH3EqualsTo(statisticType.getCaption()))
-                                                            .findFirst()
-                                                            .get()
-                                                            .getElement();
+                                                   .filter(textWithinH3EqualsTo(
+                                                           statisticType.getCaption()))
+                                                   .findFirst()
+                                                   .get()
+                                                   .getElement();
         var verticalLayoutInDiv = divContainingStatistic.getChild(0);
         return verticalLayoutInDiv;
     }
 
     private static Predicate<Component> textWithinH3EqualsTo(String text) {
         return x -> x.getElement() // DIV ->
-                .getChild(0) // VerticalLayout ->
-                .getChild(0) // H3 ->
-                .getText() // Text
-                .equals(text);
+                     .getChild(0) // VerticalLayout ->
+                     .getChild(0) // H3 ->
+                     .getText() // Text
+                     .equals(text);
     }
 
     public static void populateDataWithBooks(
@@ -70,7 +76,7 @@ public class StatisticsViewTestUtils {
         bookService.save(mobyDickBook);
         bookService.save(hobbitBook);
     }
-    
+
     public static void populateDataWithBooksWithoutPageCount(
             BookService bookService, PredefinedShelfService predefinedShelfService) {
         Book mobyDickBook = createMobyDickBook(predefinedShelfService);
@@ -99,29 +105,32 @@ public class StatisticsViewTestUtils {
     }
 
     private static PredefinedShelf getReadShelf(PredefinedShelfService predefinedShelfService) {
-        PredefinedShelfUtils predefinedShelfUtils = new PredefinedShelfUtils(predefinedShelfService);
+        PredefinedShelfUtils predefinedShelfUtils =
+                new PredefinedShelfUtils(predefinedShelfService);
         return predefinedShelfUtils.findReadShelf();
     }
 
-    private static Book createMobyDickBook(PredefinedShelfService predefinedShelfService) {
+    private static Book createBook(String title, Author author,
+                                   PredefinedShelfService predefinedShelfService, BookGenre genre,
+                                   int numberOfPages, int pagesRead, RatingScale rating) {
         PredefinedShelf readShelf = getReadShelf(predefinedShelfService);
-        Author author = new Author("Herman", "Melville");
-        Book book = new Book("Moby Dick", author, readShelf);
-        book.setBookGenre(BookGenre.ADVENTURE);
-        book.setNumberOfPages(2000);
-        book.setPagesRead(1000);
-        book.setRating(RatingScale.EIGHT_POINT_FIVE);
+        final var book = new Book(title, author, readShelf);
+        book.setBookGenre(genre);
+        book.setNumberOfPages(numberOfPages);
+        book.setPagesRead(pagesRead);
+        book.setRating(rating);
         return book;
     }
 
+    private static Book createMobyDickBook(PredefinedShelfService predefinedShelfService) {
+        final var author = new Author("Herman", "Melville");
+        return createBook("Moby Dick", author, predefinedShelfService, BookGenre.ADVENTURE, 2000,
+                1000, RatingScale.EIGHT);
+    }
+
     private static Book createHobbitBook(PredefinedShelfService predefinedShelfService) {
-        PredefinedShelf readShelf = getReadShelf(predefinedShelfService);
-        Author author = new Author("J.R.R", "Tolkien");
-        Book book = new Book("The Hobbit", author, readShelf);
-        book.setBookGenre(BookGenre.FANTASY);
-        book.setNumberOfPages(2000);
-        book.setPagesRead(1000);
-        book.setRating(RatingScale.EIGHT);
-        return book;
+        final var author = new Author("J.R.R", "Tolkien");
+        return createBook("The Hobbit", author, predefinedShelfService, BookGenre.FANTASY, 1999,
+                1110, RatingScale.EIGHT_POINT_FIVE);
     }
 }


### PR DESCRIPTION
## Summary of change

The statistics for "Most liked book" and "Least liked book" will only show if minimum two rated books are present.

## Related issue

Closes #371

## PR checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [X] Resolved any merge conflicts

If in doubt, get in touch with us via our [Slack workspace](https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw)
