### PR TITLE
Remove unnecessary repopulating of Book-bean

### DIFF
--- a/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
+++ b/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
@@ -355,13 +355,7 @@ public class BookForm extends VerticalLayout {
     }
 
     private void setBookBean() {
-        // Only repopulate if we create a new Book
-        if (binder.getBean() == null) {
-            Book book = populateBookBean();
-            if (book != null) {
-                binder.setBean(book);
-            }
-        }
+        repopulateIfCreatingANewBook();
 
         if (binder.getBean() != null) {
             LOGGER.log(Level.INFO, "Written bean. Not Null.");
@@ -373,6 +367,15 @@ public class BookForm extends VerticalLayout {
             showErrorMessage();
         }
         closeForm();
+    }
+
+    private void repopulateIfCreatingANewBook() {
+        if (binder.getBean() == null) {
+            Book book = populateBookBean();
+            if (book != null) {
+                binder.setBean(book);
+            }
+        }
     }
 
     private Book populateBookBean() {

--- a/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
+++ b/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
@@ -355,9 +355,12 @@ public class BookForm extends VerticalLayout {
     }
 
     private void setBookBean() {
-        Book book = populateBookBean();
-        if (book != null) {
-            binder.setBean(book);
+        // Only repopulate if we create a new Book
+        if (binder.getBean() == null) {
+            Book book = populateBookBean();
+            if (book != null) {
+                binder.setBean(book);
+            }
         }
 
         if (binder.getBean() != null) {

--- a/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
@@ -195,9 +195,8 @@ class BookFormTest {
         // when
         AtomicReference<Book> bookReference = new AtomicReference<>(null);
         if (eventType.equals(EventType.SAVED)) {
-            bookForm
-                    .addListener(BookForm.SaveEvent.class,
-                            event -> bookReference.set(event.getBook()));
+            bookForm.addListener(BookForm.SaveEvent.class,
+                    event -> bookReference.set(event.getBook()));
             bookForm.saveButton.click();
         } else if (eventType.equals(EventType.DELETED)) {
             bookForm.addListener(BookForm.DeleteEvent.class,
@@ -460,9 +459,7 @@ class BookFormTest {
         bookForm.setBook(book);
 
         AtomicReference<Book> bookReference = new AtomicReference<>(null);
-        bookForm
-                .addListener(BookForm.SaveEvent.class,
-                        event -> bookReference.set(event.getBook()));
+        bookForm.addListener(BookForm.SaveEvent.class, event -> bookReference.set(event.getBook()));
 
         // when
         bookForm.authorFirstName.setValue("James");

--- a/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
@@ -453,6 +453,31 @@ class BookFormTest {
     }
 
     @Test
+    void changeAuthorNameShouldBeSaved() {
+        // given
+        Book book = createBook(READ, false, "Title");
+        bookService.save(book);
+        bookForm.setBook(book);
+
+        AtomicReference<Book> bookReference = new AtomicReference<>(null);
+        bookForm
+                .addListener(BookForm.SaveEvent.class,
+                        event -> bookReference.set(event.getBook()));
+
+        // when
+        bookForm.authorFirstName.setValue("James");
+        bookForm.authorLastName.setValue("Dean");
+        bookForm.saveButton.click();
+
+        // then
+        Book savedBook = bookReference.get();
+
+        assertThat(savedBook.getId()).isEqualTo(book.getId()); // Still the same book
+        assertThat(savedBook.getAuthor().getFirstName()).isEqualTo("James"); // Author name changed
+        assertThat(savedBook.getAuthor().getLastName()).isEqualTo("Dean");
+    }
+
+    @Test
     void shouldNotAllowEmptyAuthorLastName() {
         // given
         bookForm.authorLastName.setValue("");


### PR DESCRIPTION
Removed unnecessary repopulating of Book-bean in BookForm to correctly save data for existing Books

## Summary of change

BookBean in BookForm is repopulated no matter if it's still created populated (e.g. because the Book already exists and given to the form form outside). 

## Additional context

The exception mentioned in the issue is not reproducible, different error was still thrown and author name changes didn't work as intended.

## Related issue

Closes #427 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [ ] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [ ] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

If in doubt, get in touch with us via our [Slack workspace](https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw)
