### PR TITLE
Adds instructions on how to run with Vaadin live reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,6 @@ Prerequisites:
   
 Then, if you want to use Docker, follow one of the approaches below:
 
-You may find lots of errors for things like the log statements, or the entities not having constructors. 
-You can find instructions on how to fix this for IntelliJ and Eclipse in our [troubleshooting wiki page](https://github.com/knjk04/book-project/wiki/Troubleshooting). 
-Other common errors and solutions are also in the troubleshooting page.
-
 #### 1. Start locally with only MySQL running in docker
 
 3. Build the project at the root using `./mvn clean install` (Unix) or `mvnw.cmd clean install` (Windows)
@@ -107,6 +103,12 @@ Vaadin Live reload which prevents you from needing to re-run the server every ti
    
 If you're running the app from your IDE, after making a Vaadin-related change, build the app from your IDE after making
 any changes.
+
+#### Fixing Lombok errors
+
+You may find lots of errors for things like the log statements, or the entities not having constructors. 
+You can find instructions on how to fix this for IntelliJ and Eclipse in our [troubleshooting wiki page](https://github.com/knjk04/book-project/wiki/Troubleshooting). 
+Other common errors and solutions are also in the troubleshooting page.
 
 ### Access database
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ If you want to use Docker, follow one of the two appoaches (if you use Windows, 
 3. Build the project at the root using `./mvn clean install` (Unix) or `mvnw.cmd clean install` (Windows)
 4. Start MySQL database using `docker-compose up -d mysql phpmyadmin`
 5. Start the application using `java -jar target/book-project-0.0.1-SNAPSHOT.jar` 
+
+***Live reload:*** See  your UI changes in the browser without manual refresh.
+To activate this feature start the application with `mvn spring-boot:run` (Unix) 
+or `mvnw.cmd spring-boot:run` (Windows). Please note that this feature doesn't work
+when application is started as JAR.
 6. Log in with the details below:
     - Username: `user`
     - Password: `password`

--- a/README.md
+++ b/README.md
@@ -61,13 +61,18 @@ Prerequisites:
 - MySQL 8.0.* or (better) Docker
  
 ### Running the app
-  
-If you want to use Docker, follow one of the approaches below:
-
-#### 1. Start locally with only MySQL running in docker
 
 1. Clone the repository
 2. Import the project as a maven project into your favourite IDE (or run maven on the terminal)
+  
+Then, if you want to use Docker, follow one of the approaches below:
+
+You may find lots of errors for things like the log statements, or the entities not having constructors. 
+You can find instructions on how to fix this for IntelliJ and Eclipse in our [troubleshooting wiki page](https://github.com/knjk04/book-project/wiki/Troubleshooting). 
+Other common errors and solutions are also in the troubleshooting page.
+
+#### 1. Start locally with only MySQL running in docker
+
 3. Build the project at the root using `./mvn clean install` (Unix) or `mvnw.cmd clean install` (Windows)
 4. Start the MySQL database using `docker-compose up -d mysql phpmyadmin`
 5. Start the application using `java -jar target/book-project-0.0.1-SNAPSHOT.jar` 
@@ -77,8 +82,6 @@ If you want to use Docker, follow one of the approaches below:
 
 #### 2. Start using docker-compose in production mode
 
-1. Clone the repository
-2. Import the project as a maven project into your favourite IDE (or run maven on the terminal)
 3. At the root of the project, build the project in production mode using one of the following commands. In production mode all UI components are packaged in a jar file.
     - `./mvnw clean package -Pproduction` (Unix), or 
     - `mvnw.cmd clean package -Pproduction` (Windows)
@@ -94,18 +97,16 @@ We recommended this approach if you need to work on the frontend with Vaadin. Th
 Vaadin Live reload which prevents you from needing to re-run the server every time or manually refresh your browser 
 (i.e. it's a lot quicker). 
 
-1. Start the MySQL database using `docker-compose up -d mysql phpmyadmin`
-2. Run the project from your IDE or with Maven:
+3. Start the MySQL database using `docker-compose up -d mysql phpmyadmin`
+4. Run the project from your IDE or with Maven:
    - `./mvnw spring-boot:run` on Unix
    - `mvnw.cmd spring-boot:run` on Windows
-3. Log in with the details below:
+5. Log in with the details below:
    - Username: `user`
    - Password: `password`
    
 If you're running the app from your IDE, after making a Vaadin-related change, build the app from your IDE after making
 any changes.
-    
-You may find lots of errors for things like the log statements, or the entities not having constructors. You can find instructions on how to fix this for IntelliJ and Eclipse in our [troubleshooting wiki page](https://github.com/knjk04/book-project/wiki/Troubleshooting). Other common errors and solutions are also detailed in the troubleshooting page.
 
 ### Access database
 

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ If you want to use Docker, follow one of the approaches below:
    - Username: `user`
    - Password: `password`
     
-#### 3. Run app without the tests    
+#### 3. Start locally with Vaadin live reload (the tests do not run)
 
 We recommended this approach if you need to work on the frontend with Vaadin. This approach allows you to use 
-Vaadin Live reload which prevents you from needing to re-run the server every time (i.e. it's a lot quicker) or manually
-refresh your browser. 
+Vaadin Live reload which prevents you from needing to re-run the server every time or manually refresh your browser 
+(i.e. it's a lot quicker). 
 
 1. Start the MySQL database using `docker-compose up -d mysql phpmyadmin`
 2. Run the project from your IDE or with Maven:

--- a/README.md
+++ b/README.md
@@ -62,36 +62,48 @@ Prerequisites:
  
 ### Running the app
   
-If you want to use Docker, follow one of the two appoaches (if you use Windows, follow the first approach):
+If you want to use Docker, follow one of the approaches below:
 
 #### 1. Start locally with only MySQL running in docker
 
 1. Clone the repository
 2. Import the project as a maven project into your favourite IDE (or run maven on the terminal)
 3. Build the project at the root using `./mvn clean install` (Unix) or `mvnw.cmd clean install` (Windows)
-4. Start MySQL database using `docker-compose up -d mysql phpmyadmin`
+4. Start the MySQL database using `docker-compose up -d mysql phpmyadmin`
 5. Start the application using `java -jar target/book-project-0.0.1-SNAPSHOT.jar` 
-
-***Live reload:*** See  your UI changes in the browser without manual refresh.
-To activate this feature start the application with `mvn spring-boot:run` (Unix) 
-or `mvnw.cmd spring-boot:run` (Windows). Please note that this feature doesn't work
-when application is started as JAR.
 6. Log in with the details below:
-    - Username: `user`
-    - Password: `password`
+   - Username: `user`
+   - Password: `password`
 
 #### 2. Start using docker-compose in production mode
+
 1. Clone the repository
 2. Import the project as a maven project into your favourite IDE (or run maven on the terminal)
 3. At the root of the project, build the project in production mode using one of the following commands. In production mode all UI components are packaged in a jar file.
-     - `./mvnw clean package -Pproduction` (Unix), or 
-     - `mvnw.cmd clean package -Pproduction` (Windows)
+    - `./mvnw clean package -Pproduction` (Unix), or 
+    - `mvnw.cmd clean package -Pproduction` (Windows)
 4. Start the MySQL Database and book project app using docker compose `docker-compose up --build`
 5. Go to `localhost:8080`
 6. Log in with the details below:
-    - Username: `user`
-    - Password: `password`
+   - Username: `user`
+   - Password: `password`
+    
+#### 3. Run app without the tests    
 
+We recommended this approach if you need to work on the frontend with Vaadin. This approach allows you to use 
+Vaadin Live reload which prevents you from needing to re-run the server every time (i.e. it's a lot quicker) or manually
+refresh your browser. 
+
+1. Start the MySQL database using `docker-compose up -d mysql phpmyadmin`
+2. Run the project from your IDE or with Maven:
+   - `./mvnw spring-boot:run` on Unix
+   - `mvnw.cmd spring-boot:run` on Windows
+3. Log in with the details below:
+   - Username: `user`
+   - Password: `password`
+   
+If you're running the app from your IDE, after making a Vaadin-related change, build the app from your IDE after making
+any changes.
     
 You may find lots of errors for things like the log statements, or the entities not having constructors. You can find instructions on how to fix this for IntelliJ and Eclipse in our [troubleshooting wiki page](https://github.com/knjk04/book-project/wiki/Troubleshooting). Other common errors and solutions are also detailed in the troubleshooting page.
 


### PR DESCRIPTION
## Summary of change

As discussed here https://teambookproject.slack.com/archives/C01AGDC5X1S/p1601991038033600, there is no way to make live reload work when the application is run as a JAR because vaadin doesn't support passing authentication details when using live reload feature. This change adds a note to the readme that shows how to run application locally with live reload feature enabled.

## Related issue

Closes #407 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

If in doubt, get in touch with us via our [Slack workspace](https://join.slack.com/t/teambookproject/shared_invite/zt-h6vx3n8l-KN8QnO50r7QWZHgHFnFdPw)
