### PR TITLE
Fixing variable shadowing on PageStatistics::findBooksWithPageCountSpecified

### DIFF
--- a/src/main/java/com/karankumar/bookproject/backend/statistics/PageStatistics.java
+++ b/src/main/java/com/karankumar/bookproject/backend/statistics/PageStatistics.java
@@ -45,13 +45,13 @@ public class PageStatistics extends Statistics {
     }
 
     private List<Book> findBooksWithPageCountSpecified() {
-        List<Book> booksWithPageCount = new ArrayList<>();
+        List<Book> booksWithNonEmptyPageCount = new ArrayList<>();
         for (Book book : readShelfBooks) {
             if (book.getNumberOfPages() != null) {
-                booksWithPageCount.add(book);
+                booksWithNonEmptyPageCount.add(book);
             }
         }
-        return booksWithPageCount;
+        return booksWithNonEmptyPageCount;
     }
 
     /**


### PR DESCRIPTION
## Summary of change

Renaming variable 'booksWithPageCount' on PageStatistics::findBooksWithPageCountSpecified to avoid variable shadowing.

## Related issue

Closes #397 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x]  Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).

  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

Resolved any merge conflicts