### PR TITLE
Replace deprecated ServletHelper with HandlerHelper

### DIFF
--- a/src/main/java/com/karankumar/bookproject/security/SecurityUtils.java
+++ b/src/main/java/com/karankumar/bookproject/security/SecurityUtils.java
@@ -17,7 +17,7 @@
 
 package com.karankumar.bookproject.security;
 
-import com.vaadin.flow.server.ServletHelper;
+import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.shared.ApplicationConstants;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -35,7 +35,7 @@ public final class SecurityUtils {
         final String parameterValue =
             request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER);
         return parameterValue != null
-            && Stream.of(ServletHelper.RequestType.values())
+            && Stream.of(HandlerHelper.RequestType.values())
             .anyMatch(r -> r.getIdentifier().equals(parameterValue));
     }
 


### PR DESCRIPTION
## Summary of change

I have replaced the deprecated ServletHelper class in the SecurityUtils class with the HandlerHelper class as recommended by Vaadin guidelines.


## Related issue

Closes #494 

## Pull request checklist

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts