### PR TITLE
Fetch custom shelf before updating a book

### DIFF
--- a/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
+++ b/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
@@ -357,6 +357,7 @@ public class BookForm extends VerticalLayout {
         repopulateIfCreatingANewBook();
 
         if (binder.getBean() != null) {
+            populateBookShelf();
             LOGGER.log(Level.INFO, "Written bean. Not Null.");
             ComponentUtil.clearComponentFields(fieldsToReset);
             fireEvent(new SaveEvent(this, binder.getBean()));
@@ -366,6 +367,21 @@ public class BookForm extends VerticalLayout {
             showErrorMessage();
         }
         closeForm();
+    }
+
+    /**
+     * We need to fetch the complete {@link CustomShelf} entity as we store (and therefor submit) only the custom shelf name. See {@see BookForm#configureCustomShelfField}
+     */
+    private void populateBookShelf() {
+        Book book = binder.getBean();
+        CustomShelf selectedCustomShelf = book.getCustomShelf();
+        if (selectedCustomShelf != null) {
+            String shelfName = selectedCustomShelf.getShelfName();
+            CustomShelf completeCustomShelf = customShelfService.findByShelfNameAndLoggedInUser(shelfName);
+            if (completeCustomShelf != null) {
+                book.setCustomShelf(completeCustomShelf);
+            }
+        }
     }
 
     private void repopulateIfCreatingANewBook() {


### PR DESCRIPTION
* necessary in order not to update the shelf linked to the book properly

## Summary of change

Fetch custom shelf data by name before updating edited books.

## Additional context

When updating a book, such as editing the authors name, we submit the book object to the backend. The book contains the name of the custom shelf but do not contain further informations such as the custom shelf ID. That results in creating a new custom shelf entity, even though the custom shelf already exists. Due to a constraint of a unique_index field, populated for that new shelf entity through user ID + custom shelf name this ends up in SQL exceptions.

## Related issue

Closes #500 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.

If in doubt, get in touch with us via our [Slack workspace](https://join.slack.com/t/teambookproject/shared_invite/zt-i7lept44-rgJ9yB0A2vedJTLyyfkjKQ)
