### PR TITLE
add NonNull annotations to save() and delete() in services

### DIFF
--- a/src/main/java/com/karankumar/bookproject/backend/service/BookService.java
+++ b/src/main/java/com/karankumar/bookproject/backend/service/BookService.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.karankumar.bookproject.backend.entity.Author;
 import com.karankumar.bookproject.backend.entity.Book;
 import com.karankumar.bookproject.backend.repository.BookRepository;
+import lombok.NonNull;
 import lombok.extern.java.Log;
 import org.springframework.stereotype.Service;
 
@@ -80,16 +81,9 @@ public class BookService {
         return bookRepository.findByTitleContainingIgnoreCase(filterText);
     }
 
-    public void delete(Book book) {
-        if (book == null) {
-            LOGGER.log(Level.SEVERE, "Cannot delete an null book.");
-            return;
-        }
-
-
+    public void delete(@NonNull Book book) {
         LOGGER.log(Level.INFO, "Deleting book. Book repository size = " + bookRepository.count());
         bookRepository.delete(book);
-
 
         List<Book> books = bookRepository.findAll();
         if (books.contains(book)) {

--- a/src/main/java/com/karankumar/bookproject/backend/service/BookService.java
+++ b/src/main/java/com/karankumar/bookproject/backend/service/BookService.java
@@ -55,8 +55,8 @@ public class BookService {
         }
     }
 
-    private boolean bookHasAuthorAndPredefinedShelf(Book book) {
-        return book != null && book.getAuthor() != null && book.getPredefinedShelf() != null;
+    private boolean bookHasAuthorAndPredefinedShelf(@NonNull Book book) {
+        return book.getAuthor() != null && book.getPredefinedShelf() != null;
     }
 
     private void addBookToAuthor(Book book) {

--- a/src/main/java/com/karankumar/bookproject/backend/service/CustomShelfService.java
+++ b/src/main/java/com/karankumar/bookproject/backend/service/CustomShelfService.java
@@ -19,6 +19,7 @@ package com.karankumar.bookproject.backend.service;
 
 import com.karankumar.bookproject.backend.entity.CustomShelf;
 import com.karankumar.bookproject.backend.repository.CustomShelfRepository;
+import lombok.NonNull;
 import lombok.extern.java.Log;
 import org.springframework.stereotype.Service;
 
@@ -51,11 +52,11 @@ public class CustomShelfService {
         return customShelfRepository.findByShelfNameAndUser(shelfName, userService.getCurrentUser());
     }
 
-    public void save(CustomShelf customShelf) {
+    public void save(@NonNull CustomShelf customShelf) {
         customShelfRepository.save(customShelf);
     }
 
-    public void delete(CustomShelf customShelf) {
+    public void delete(@NonNull CustomShelf customShelf) {
         customShelfRepository.delete(customShelf);
     }
 

--- a/src/main/java/com/karankumar/bookproject/backend/service/PredefinedShelfService.java
+++ b/src/main/java/com/karankumar/bookproject/backend/service/PredefinedShelfService.java
@@ -24,6 +24,7 @@ import com.karankumar.bookproject.backend.repository.AuthorRepository;
 import com.karankumar.bookproject.backend.repository.BookRepository;
 import com.karankumar.bookproject.backend.repository.PredefinedShelfRepository;
 import com.karankumar.bookproject.backend.repository.TagRepository;
+import lombok.NonNull;
 import lombok.extern.java.Log;
 import org.springframework.stereotype.Service;
 
@@ -62,13 +63,8 @@ public class PredefinedShelfService {
         return predefinedShelfRepository.getOne(id);
     }
 
-    public void save(PredefinedShelf shelf) {
-        if (shelf != null) {
-            LOGGER.log(Level.INFO, "Saving shelf: " + shelf);
-            predefinedShelfRepository.save(shelf);
-        } else {
-            LOGGER.log(Level.SEVERE, "Null Shelf");
-        }
+    public void save(@NonNull PredefinedShelf shelf) {
+        predefinedShelfRepository.save(shelf);
     }
 
     public List<PredefinedShelf> findAllForLoggedInUser() {

--- a/src/main/java/com/karankumar/bookproject/backend/service/TagService.java
+++ b/src/main/java/com/karankumar/bookproject/backend/service/TagService.java
@@ -19,6 +19,7 @@ package com.karankumar.bookproject.backend.service;
 
 import com.karankumar.bookproject.backend.entity.Tag;
 import com.karankumar.bookproject.backend.repository.TagRepository;
+import lombok.NonNull;
 import lombok.extern.java.Log;
 import org.springframework.stereotype.Service;
 
@@ -39,12 +40,8 @@ public class TagService {
         return tagRepository.getOne(id);
     }
 
-    public void save(Tag tag) {
-        if (tag != null) {
-            tagRepository.save(tag);
-        } else {
-            LOGGER.log(Level.SEVERE, "Null tag");
-        }
+    public void save(@NonNull Tag tag) {
+        tagRepository.save(tag);
     }
 
     public Long count() {
@@ -55,7 +52,7 @@ public class TagService {
         return tagRepository.findAll();
     }
 
-    public void delete(Tag tag) {
+    public void delete(@NonNull Tag tag) {
         tagRepository.delete(tag);
     }
 

--- a/src/main/java/com/karankumar/bookproject/backend/service/UserService.java
+++ b/src/main/java/com/karankumar/bookproject/backend/service/UserService.java
@@ -21,6 +21,7 @@ import com.karankumar.bookproject.backend.entity.account.Role;
 import com.karankumar.bookproject.backend.entity.account.User;
 import com.karankumar.bookproject.backend.repository.RoleRepository;
 import com.karankumar.bookproject.backend.repository.UserRepository;
+import lombok.NonNull;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -53,7 +54,7 @@ public class UserService {
         this.authenticationManager = authenticationManager;
     }
 
-    public void register(User user) throws UserAlreadyRegisteredException {
+    public void register(@NonNull User user) throws UserAlreadyRegisteredException {
         Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
         Set<ConstraintViolation<User>> constraintViolations = validator.validate(user);
 

--- a/src/test/java/com/karankumar/bookproject/backend/service/BookServiceTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/service/BookServiceTest.java
@@ -37,7 +37,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;

--- a/src/test/java/com/karankumar/bookproject/backend/service/BookServiceTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/service/BookServiceTest.java
@@ -95,13 +95,14 @@ class BookServiceTest {
     }
 
     @Test
-    void notSaveNullBook() {
-        bookService.save(null);
-        assertThat(bookService.count()).isZero();
+    @DisplayName("throw an exception when there is an attempt to save a null book")
+    void throwExceptionWhenSavingANullBook() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> bookService.save(null));
     }
 
     @Test
-    void notSaveBookWithout() {
+    void notSaveBookWithoutAuthor() {
         SoftAssertions softly = new SoftAssertions();
 
         // when

--- a/src/test/java/com/karankumar/bookproject/backend/service/BookServiceTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/service/BookServiceTest.java
@@ -29,13 +29,15 @@ import com.karankumar.bookproject.backend.entity.RatingScale;
 import org.apache.commons.io.FileUtils;
 
 import static com.karankumar.bookproject.backend.entity.PredefinedShelf.ShelfName.TO_READ;
-import static org.assertj.core.api.Assertions.assertThat;
+
 import org.assertj.core.api.SoftAssertions;
 import org.json.JSONException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -139,6 +141,13 @@ class BookServiceTest {
               .isInstanceOf(TransactionSystemException.class);
         softly.assertThat(bookService.count()).isZero();
         softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("throw an exception when there is an attempt to delete a null book")
+    void throwExceptionWhenDeletingANullBook() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> bookService.delete(null));
     }
 
     @Test

--- a/src/test/java/com/karankumar/bookproject/backend/service/CustomShelfServiceTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/service/CustomShelfServiceTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import static com.karankumar.bookproject.util.SecurityTestUtils.TEST_USER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @IntegrationTest
@@ -86,5 +87,19 @@ class CustomShelfServiceTest {
             softly.assertThat(shelf.getShelfName()).isEqualTo(name);
             softly.assertThat(shelf.getUser().getUsername()).isEqualTo(TEST_USER_NAME);
         });
+    }
+
+    @Test
+    @DisplayName("throw an error on an attempt to save a null custom shelf")
+    void throwErrorWhenSavingANullCustomShelf() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> customShelfService.save(null));
+    }
+
+    @Test
+    @DisplayName("throw an error on an attempt to delete a null custom shelf")
+    void throwErrorWhenDeletingANullCustomShelf() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> customShelfService.delete(null));
     }
 }

--- a/src/test/java/com/karankumar/bookproject/backend/service/PredefinedShelfServiceTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/service/PredefinedShelfServiceTest.java
@@ -22,6 +22,7 @@ import com.karankumar.bookproject.backend.entity.PredefinedShelf;
 
 import static com.karankumar.bookproject.util.SecurityTestUtils.TEST_USER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.karankumar.bookproject.backend.repository.UserRepository;
@@ -50,15 +51,10 @@ class PredefinedShelfServiceTest {
     }
 
     @Test
+    @DisplayName("throw an exception on an attempt to save a null predefined shelf")
     void notSaveNullPredefinedShelf() {
-        // given
-        long initialCount = predefinedShelfService.count();
-
-        // when
-        predefinedShelfService.save(null);
-
-        // then
-        assertThat(predefinedShelfService.count()).isEqualTo(initialCount);
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> predefinedShelfService.save(null));
     }
 
     @Test

--- a/src/test/java/com/karankumar/bookproject/backend/service/TagServiceTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/service/TagServiceTest.java
@@ -2,9 +2,7 @@ package com.karankumar.bookproject.backend.service;
 
 import com.karankumar.bookproject.annotations.IntegrationTest;
 import com.karankumar.bookproject.backend.entity.Tag;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assumptions.assumeThat;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +11,10 @@ import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
 
 import javax.transaction.Transactional;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @IntegrationTest
 @DisplayName("TagService should")
@@ -41,15 +43,17 @@ class TagServiceTest {
     }
 
     @Test
-    void notSaveANullTag() {
-        // given
-        assumeThat(tagService.count()).isZero();
+    @DisplayName("throw exception on an attempt to save a null tag")
+    void throwExceptionWhenSavingANullTag() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> tagService.save(null));
+    }
 
-        // when
-        tagService.save(null);
-
-        // then
-        assertThat(tagService.count()).isZero();
+    @Test
+    @DisplayName("throw exception on an attempt to delete a null tag")
+    void throwExceptionWhenDeletingANullTag() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> tagService.delete(null));
     }
 
     @Test

--- a/src/test/java/com/karankumar/bookproject/backend/service/UserServiceTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/service/UserServiceTest.java
@@ -39,6 +39,7 @@ import static com.karankumar.bookproject.util.SecurityTestUtils.TEST_USER_NAME;
 import static com.karankumar.bookproject.util.SecurityTestUtils.getTestUser;
 import static com.karankumar.bookproject.util.SecurityTestUtils.insertTestUser;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @IntegrationTest
@@ -97,6 +98,13 @@ class UserServiceTest {
     void throwExceptionOnRegisterWithoutUserRole() {
         assertThatThrownBy(() -> userService.register(validUser))
                 .isInstanceOf(AuthenticationServiceException.class);
+    }
+
+    @Test
+    @DisplayName("throw an exception on an attempt to register a null user")
+    void throwExceptionWhenRegisteringNullUser() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> userService.register(null));
     }
 
     @Test


### PR DESCRIPTION
## Summary of change

- Add `@NonNull` annotations to the save() and delete() methods of the services
- Write tests to ensure that null pointer exceptions are thrown if null is passed into a save() or delete() method

## Related issue

Closes #510 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.

If in doubt, get in touch with us via our [Slack workspace](https://join.slack.com/t/teambookproject/shared_invite/zt-i7lept44-rgJ9yB0A2vedJTLyyfkjKQ)
