### PR TITLE
Improve DateUtils test coverage

### DIFF
--- a/src/main/java/com/karankumar/bookproject/backend/util/DateUtils.java
+++ b/src/main/java/com/karankumar/bookproject/backend/util/DateUtils.java
@@ -32,7 +32,7 @@ public final class DateUtils {
     private DateUtils() {}
 
     public static int getCurrentWeekNumberOfYear() {
-        LocalDateTime now = TimeUtils.now();
+        LocalDateTime now = TimeUtils.currentDateTime();
         TemporalField week = TimeUtils.getWeekFields().weekOfWeekBasedYear();
         return now.get(week);
     }
@@ -42,19 +42,23 @@ public final class DateUtils {
     }
 
     public static boolean dateIsInCurrentYear(@NotNull LocalDate date) {
-        return date.getYear() == LocalDate.now().getYear();
-
+        return date.getYear() == TimeUtils.currentDate().getYear();
     }
+
     public static boolean isDateInFuture(LocalDate date) {
-        return date.isAfter(LocalDate.now());
+        return date.isAfter(TimeUtils.currentDate());
     }
 
     @VisibleForTesting
     static final class TimeUtils {
         private TimeUtils() {}
 
-        static LocalDateTime now() {
+        static LocalDateTime currentDateTime() {
             return LocalDateTime.now();
+        }
+
+        static LocalDate currentDate() {
+            return LocalDate.now();
         }
 
         static WeekFields getWeekFields() {

--- a/src/test/java/com/karankumar/bookproject/backend/goal/ReadingGoalCalculatorTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/goal/ReadingGoalCalculatorTest.java
@@ -27,12 +27,14 @@ import com.karankumar.bookproject.backend.util.DateUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.time.LocalDate;
@@ -40,10 +42,16 @@ import java.time.LocalDate;
 @DisplayName("ReadingGoalCalculator should")
 class ReadingGoalCalculatorTest {
     private final int BOOKS_TO_READ = 52;
+    private static MockedStatic<DateUtils> mockDateUtils;
 
     @BeforeAll
     static void setUp() {
-        Mockito.mockStatic(DateUtils.class);
+        mockDateUtils = Mockito.mockStatic(DateUtils.class);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        mockDateUtils.close();
     }
 
     @Test

--- a/src/test/java/com/karankumar/bookproject/backend/util/DateUtilsTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/util/DateUtilsTest.java
@@ -18,10 +18,11 @@
 package com.karankumar.bookproject.backend.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.time.LocalDate;
@@ -32,14 +33,20 @@ import java.util.Locale;
 class DateUtilsTest {
 
     private static final LocalDate MOCK_CURRENT_DATE = LocalDate.of(2020, 6, 1);
+    private static MockedStatic<DateUtils.TimeUtils> mockDateUtils;
 
     @BeforeAll
     static void setup() {
-        Mockito.mockStatic(DateUtils.TimeUtils.class);
+        mockDateUtils = Mockito.mockStatic(DateUtils.TimeUtils.class);
         Mockito.when(DateUtils.TimeUtils.getWeekFields())
                .thenReturn(WeekFields.of(Locale.getDefault()));
         Mockito.when(DateUtils.TimeUtils.currentDate())
                .thenReturn(MOCK_CURRENT_DATE);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        mockDateUtils.close();
     }
 
     private int mockFirstWeekOfYear() {
@@ -62,8 +69,6 @@ class DateUtilsTest {
     }
 
     @Test
-    @Disabled
-    // TODO: fix static mocking (issue 311)
     void correctlyGetWeekNumberOfYear() {
         assertThat(mockFirstWeekOfYear()).isOne();
         assertThat(mockFortiethWeekOfYear()).isEqualTo(40);
@@ -71,8 +76,6 @@ class DateUtilsTest {
     }
 
     @Test
-    @Disabled
-    // TODO: fix static mocking (issue 311)
     void correctlyGetWeeksLeftInYearFromCurrentWeek() {
         assertThat(DateUtils.calculateWeeksLeftInYearFromCurrentWeek(mockFirstWeekOfYear()))
                 .isEqualTo(calculateWeeksLeftInYear(1));
@@ -85,8 +88,6 @@ class DateUtilsTest {
     }
 
     @Test
-    @Disabled
-    // TODO: fix static mocking (issue 311)
     void correctlyCheckIfDateIsInCurrentYear() {
         LocalDate lastDayOfYear = LocalDate.of(MOCK_CURRENT_DATE.getYear(), 12, 31);
 
@@ -99,8 +100,6 @@ class DateUtilsTest {
     }
 
     @Test
-    @Disabled
-    // TODO: fix static mocking (issue 311)
     void correctlyCheckIfDateIsInFuture() {
         assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.plusYears(1))).isTrue();
         assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.plusDays(1))).isTrue();

--- a/src/test/java/com/karankumar/bookproject/backend/util/DateUtilsTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/util/DateUtilsTest.java
@@ -19,6 +19,7 @@ package com.karankumar.bookproject.backend.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -61,6 +62,8 @@ class DateUtilsTest {
     }
 
     @Test
+    @Disabled
+    // TODO: fix static mocking (issue 311)
     void correctlyGetWeekNumberOfYear() {
         assertThat(mockFirstWeekOfYear()).isOne();
         assertThat(mockFortiethWeekOfYear()).isEqualTo(40);
@@ -68,6 +71,8 @@ class DateUtilsTest {
     }
 
     @Test
+    @Disabled
+    // TODO: fix static mocking (issue 311)
     void correctlyGetWeeksLeftInYearFromCurrentWeek() {
         assertThat(DateUtils.calculateWeeksLeftInYearFromCurrentWeek(mockFirstWeekOfYear()))
                 .isEqualTo(calculateWeeksLeftInYear(1));
@@ -80,6 +85,8 @@ class DateUtilsTest {
     }
 
     @Test
+    @Disabled
+    // TODO: fix static mocking (issue 311)
     void correctlyCheckIfDateIsInCurrentYear() {
         LocalDate lastDayOfYear = LocalDate.of(MOCK_CURRENT_DATE.getYear(), 12, 31);
 
@@ -92,6 +99,8 @@ class DateUtilsTest {
     }
 
     @Test
+    @Disabled
+    // TODO: fix static mocking (issue 311)
     void correctlyCheckIfDateIsInFuture() {
         assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.plusYears(1))).isTrue();
         assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.plusDays(1))).isTrue();

--- a/src/test/java/com/karankumar/bookproject/backend/util/DateUtilsTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/util/DateUtilsTest.java
@@ -94,10 +94,13 @@ class DateUtilsTest {
 
         assertSoftly(softly -> {
             softly.assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE)).isTrue();
-            softly.assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.minusDays(1))).isTrue();
+            softly.assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.minusDays(1)))
+                  .isTrue();
             softly.assertThat(DateUtils.dateIsInCurrentYear(lastDayOfYear)).isTrue();
-            softly.assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.minusYears(1))).isFalse();
-            softly.assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.plusYears(1))).isFalse();
+            softly.assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.minusYears(1)))
+                  .isFalse();
+            softly.assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.plusYears(1)))
+                  .isFalse();
         });
     }
 

--- a/src/test/java/com/karankumar/bookproject/backend/util/DateUtilsTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/util/DateUtilsTest.java
@@ -18,6 +18,7 @@
 package com.karankumar.bookproject.backend.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -91,22 +92,24 @@ class DateUtilsTest {
     void correctlyCheckIfDateIsInCurrentYear() {
         LocalDate lastDayOfYear = LocalDate.of(MOCK_CURRENT_DATE.getYear(), 12, 31);
 
-        assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE)).isTrue();
-        assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.minusDays(1))).isTrue();
-        assertThat(DateUtils.dateIsInCurrentYear(lastDayOfYear)).isTrue();
-
-        assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.minusYears(1))).isFalse();
-        assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.plusYears(1))).isFalse();
+        assertSoftly(softly -> {
+            softly.assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE)).isTrue();
+            softly.assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.minusDays(1))).isTrue();
+            softly.assertThat(DateUtils.dateIsInCurrentYear(lastDayOfYear)).isTrue();
+            softly.assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.minusYears(1))).isFalse();
+            softly.assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.plusYears(1))).isFalse();
+        });
     }
 
     @Test
     void correctlyCheckIfDateIsInFuture() {
-        assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.plusYears(1))).isTrue();
-        assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.plusDays(1))).isTrue();
-
-        assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE)).isFalse();
-        assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.minusDays(1))).isFalse();
-        assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.minusMonths(1))).isFalse();
+        assertSoftly(softly -> {
+            softly.assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.plusYears(1))).isTrue();
+            softly.assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.plusDays(1))).isTrue();
+            softly.assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE)).isFalse();
+            softly.assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.minusDays(1))).isFalse();
+            softly.assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.minusMonths(1))).isFalse();
+        });
     }
 
     private int calculateWeeksLeftInYear(int currentWeekNumber) {

--- a/src/test/java/com/karankumar/bookproject/backend/util/DateUtilsTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/util/DateUtilsTest.java
@@ -19,45 +19,48 @@ package com.karankumar.bookproject.backend.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.WeekFields;
 import java.util.Locale;
 @DisplayName("DateUtils should")
 class DateUtilsTest {
+
+    private static final LocalDate MOCK_CURRENT_DATE = LocalDate.of(2020, 6, 1);
+
     @BeforeAll
     static void setup() {
         Mockito.mockStatic(DateUtils.TimeUtils.class);
         Mockito.when(DateUtils.TimeUtils.getWeekFields())
                .thenReturn(WeekFields.of(Locale.getDefault()));
+        Mockito.when(DateUtils.TimeUtils.currentDate())
+               .thenReturn(MOCK_CURRENT_DATE);
     }
 
     private int mockFirstWeekOfYear() {
-        Mockito.when(DateUtils.TimeUtils.now())
+        Mockito.when(DateUtils.TimeUtils.currentDateTime())
                .thenReturn(LocalDateTime.of(2020, 1, 1, 1, 1)
         );
         return DateUtils.getCurrentWeekNumberOfYear();
     }
 
     private int mockFortiethWeekOfYear() {
-        Mockito.when(DateUtils.TimeUtils.now())
+        Mockito.when(DateUtils.TimeUtils.currentDateTime())
                .thenReturn(LocalDateTime.of(2020, 10, 1, 1, 1));
         return DateUtils.getCurrentWeekNumberOfYear();
     }
 
     private int mockLastWeekOfYear() {
-        Mockito.when(DateUtils.TimeUtils.now())
+        Mockito.when(DateUtils.TimeUtils.currentDateTime())
                .thenReturn(LocalDateTime.of(2020, 12, 25, 1, 1));
         return DateUtils.getCurrentWeekNumberOfYear();
     }
 
     @Test
-    @Disabled
-    // TODO: fix failing test
     void correctlyGetWeekNumberOfYear() {
         assertThat(mockFirstWeekOfYear()).isOne();
         assertThat(mockFortiethWeekOfYear()).isEqualTo(40);
@@ -65,8 +68,6 @@ class DateUtilsTest {
     }
 
     @Test
-    @Disabled
-    // TODO: fix failing test
     void correctlyGetWeeksLeftInYearFromCurrentWeek() {
         assertThat(DateUtils.calculateWeeksLeftInYearFromCurrentWeek(mockFirstWeekOfYear()))
                 .isEqualTo(calculateWeeksLeftInYear(1));
@@ -76,6 +77,28 @@ class DateUtilsTest {
 
         assertThat(DateUtils.calculateWeeksLeftInYearFromCurrentWeek(mockLastWeekOfYear()))
                 .isEqualTo(calculateWeeksLeftInYear(mockLastWeekOfYear()));
+    }
+
+    @Test
+    void correctlyCheckIfDateIsInCurrentYear() {
+        LocalDate lastDayOfYear = LocalDate.of(MOCK_CURRENT_DATE.getYear(), 12, 31);
+
+        assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE)).isTrue();
+        assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.minusDays(1))).isTrue();
+        assertThat(DateUtils.dateIsInCurrentYear(lastDayOfYear)).isTrue();
+
+        assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.minusYears(1))).isFalse();
+        assertThat(DateUtils.dateIsInCurrentYear(MOCK_CURRENT_DATE.plusYears(1))).isFalse();
+    }
+
+    @Test
+    void correctlyCheckIfDateIsInFuture() {
+        assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.plusYears(1))).isTrue();
+        assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.plusDays(1))).isTrue();
+
+        assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE)).isFalse();
+        assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.minusDays(1))).isFalse();
+        assertThat(DateUtils.isDateInFuture(MOCK_CURRENT_DATE.minusMonths(1))).isFalse();
     }
 
     private int calculateWeeksLeftInYear(int currentWeekNumber) {


### PR DESCRIPTION
## Summary of change
Added testing for new functionality in DateUtils. Fixed the static mocking issue in #311 on the way.

## Related issue

Closes #535 
Closes #311

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.

If in doubt, get in touch with us via our [Slack workspace](https://join.slack.com/t/teambookproject/shared_invite/zt-i7lept44-rgJ9yB0A2vedJTLyyfkjKQ)
