### PR TITLE
Add PasswordStrengthMeter to the register form 607

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "typescript": "^4.0.3",
-    "web-vitals": "^0.2.4"
+    "web-vitals": "^0.2.4",
+    "zxcvbn": "^4.4.2"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -47,6 +48,7 @@
     ]
   },
   "devDependencies": {
-    "@types/react-router-dom": "^5.1.7"
+    "@types/react-router-dom": "^5.1.7",
+    "@types/zxcvbn": "^4.4.0"
   }
 }

--- a/frontend/src/shared/form/PasswordStrengthMeter.tsx
+++ b/frontend/src/shared/form/PasswordStrengthMeter.tsx
@@ -1,0 +1,82 @@
+/*
+The book project lets a user keep track of different books they would like to read, are currently
+reading, have read or did not finish.
+Copyright (C) 2020  Karan Kumar
+
+This program is free software: you can redistribute it and/or modify it under the terms of the
+GNU General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program.
+If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { LinearProgress, makeStyles } from "@material-ui/core"
+
+type StyleProps = {
+  color: string
+}
+
+type PasswordStrengthMeterProps = {
+  score?: number
+}
+
+interface PasswordMeter {
+  progress: number;
+  color: string;
+  descriptor: string;
+}
+
+const PASSWORD_STRENGTH = "Password Strength: ";
+
+const STRENGTH_METERS: { [score: number]: PasswordMeter } = {
+  0: { progress: 20, color: '#ef2929', descriptor: PASSWORD_STRENGTH + 'Weak' },
+  1: { progress: 40, color: '#f57900', descriptor: PASSWORD_STRENGTH + 'Fair' },
+  2: { progress: 60, color: '#fbe209', descriptor: PASSWORD_STRENGTH + 'Good' },
+  3: { progress: 80, color: '#00ff40', descriptor: PASSWORD_STRENGTH + 'Strong' },
+  4: { progress: 100, color: '#008000', descriptor: PASSWORD_STRENGTH + 'Very strong' },
+}
+
+const useStyles = makeStyles({
+  barColorPrimary: (props: StyleProps) => ({
+    backgroundColor: props.color
+  }),
+});
+
+function isPasswordBlank(score?: number): score is undefined {
+  return score === undefined;
+}
+
+function calculatePasswordMeter(score?: number): PasswordMeter {
+  const blankPassword: PasswordMeter = {
+    color: '#ef2929',
+    progress: 0,
+    descriptor: 'Password is blank',
+  }
+
+  if (isPasswordBlank(score)) {
+    return blankPassword
+  }
+
+  return STRENGTH_METERS[score]
+}
+
+function PasswordStrengthMeter({ score }: PasswordStrengthMeterProps) {
+  const { color, progress, descriptor }: PasswordMeter = calculatePasswordMeter(score);
+  const classes = useStyles({ color });
+  return (
+    <div>
+      <LinearProgress
+        classes={{ barColorPrimary: classes.barColorPrimary }}
+        variant="determinate"
+        value={progress} />
+      {descriptor}
+    </div>
+  );
+}
+
+export default PasswordStrengthMeter;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1966,6 +1966,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/zxcvbn@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@types/zxcvbn/-/zxcvbn-4.4.0.tgz#fbc1d941cc6d9d37d18405c513ba6b294f89b609"
+  integrity sha512-GQLOT+SN20a+AI51y3fAimhyTF4Y0RG+YP3gf91OibIZ7CJmPFgoZi+ZR5a+vRbS01LbQosITWum4ATmJ1Z6Pg==
+
 "@typescript-eslint/eslint-plugin@^4.5.0":
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.8.1.tgz#b362abe0ee478a6c6d06c14552a6497f0b480769"
@@ -11752,3 +11757,8 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+zxcvbn@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
+  integrity sha1-KOwXzwl0PtyrBW3dixsGJizHPDA=


### PR DESCRIPTION
## Summary of change

Added PasswordStrengthMeter component that renders a password meter (gif) based on score.
Added [zxcvbn](https://yarnpkg.com/package/zxcvbn) yarn package
Calculate passwordScore in Register component using zxcvbn and render PasswordStrengthMeter

## Additional context

![passwordmeter](https://user-images.githubusercontent.com/51190750/105975889-c9f81280-608f-11eb-8fb5-076a66264f31.gif)


## Related issue

Closes #607 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.

If in doubt, get in touch with us via our [Slack workspace](https://join.slack.com/t/teambookproject/shared_invite/zt-jcijyenp-JiKFGBv62FIPoFnvOW6Ubg)
