### PR TITLE
Fix transient object exception 639

### DIFF
--- a/backend/src/main/java/com/karankumar/bookproject/backend/model/Book.java
+++ b/backend/src/main/java/com/karankumar/bookproject/backend/model/Book.java
@@ -107,6 +107,7 @@ public class Book {
             cascade = {CascadeType.DETACH, CascadeType.MERGE, CascadeType.REFRESH}
     )
     @JoinColumn(name = "predefined_shelf_id", referencedColumnName = "id")
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     private PredefinedShelf predefinedShelf;
 
     @ManyToOne(
@@ -129,6 +130,7 @@ public class Book {
             )
     )
     @Setter(AccessLevel.NONE)
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     private Set<Tag> tags = new HashSet<>();
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.MERGE, CascadeType.REFRESH})
@@ -137,7 +139,8 @@ public class Book {
             joinColumns = @JoinColumn(name = "book_id", referencedColumnName = "id"),
             inverseJoinColumns = @JoinColumn(name = "publisher_id", referencedColumnName = "id")
     )
-    private Set<Publisher> publishers;
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+    private Set<Publisher> publishers = new HashSet<>();
 
     // For books that have been read
     private RatingScale rating;
@@ -187,6 +190,9 @@ public class Book {
     }
 
     public void addTag(@NonNull Tag tag) {
+        if (tags == null) {
+            tags = new HashSet<>();
+        }
         tags.add(tag);
         tag.getBooks().add(this);
     }

--- a/backend/src/main/java/com/karankumar/bookproject/backend/model/PredefinedShelf.java
+++ b/backend/src/main/java/com/karankumar/bookproject/backend/model/PredefinedShelf.java
@@ -56,6 +56,7 @@ public class PredefinedShelf extends Shelf {
     private ShelfName predefinedShelfName;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "predefinedShelf")
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     protected Set<Book> books;
 
     public PredefinedShelf(ShelfName predefinedShelfName, User user) {

--- a/backend/src/test/java/com/karankumar/bookproject/backend/service/BookServiceTest.java
+++ b/backend/src/test/java/com/karankumar/bookproject/backend/service/BookServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * The book project lets a user keep track of different books they would like to read, are currently
  * reading, have read or did not finish.
- * Copyright (C) 2020  Karan Kumar
+ * Copyright (C) 2021  Karan Kumar
 
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -41,10 +41,7 @@ import javax.validation.ConstraintViolationException;
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDate;
-
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -67,7 +64,7 @@ class BookServiceTest {
     private final PublisherService publisherService;
 
     private PredefinedShelf toRead;
-    private final Author author = new Author("First Last");
+    private final Author author = new Author("Test Full Name");
     private final Set<Publisher> publishers = Stream.of(
             new Publisher("Test Publisher")).collect(Collectors.toSet()
     );
@@ -103,6 +100,7 @@ class BookServiceTest {
         authorService.deleteAll();
         customShelfService.deleteAll();
         publisherService.deleteAll();
+        tagService.deleteAll();
     }
 
     @Test
@@ -226,10 +224,18 @@ class BookServiceTest {
     }
 
     @Test
+    @Transactional
     void createJsonRepresentationForBooks() throws IOException, JSONException {
         // given
-        bookService.save(validBook().build());
+        bookService.save(new Book("Book Name", author, toRead));
         Book anotherValidBook = createBookWithAllAttributes().build();
+
+        Tag tag1 = new Tag("adventure");
+        tagService.save(tag1);
+        anotherValidBook.addTag(tag1);
+        Tag tag2 = new Tag("book");
+        tagService.save(tag2);
+        anotherValidBook.addTag(tag2);
         bookService.save(anotherValidBook);
 
         String expectedJsonString = FileUtils.readFileToString(
@@ -270,7 +276,6 @@ class BookServiceTest {
                 .isbn("9780151010264")
                 .yearOfPublication(2014)
                 .customShelf(createAndSaveCustomShelf())
-                .tags(createAndSaveTags())
                 .rating(RatingScale.EIGHT)
                 .dateStartedReading(LocalDate.of(2020, 7, 5))
                 .dateFinishedReading(LocalDate.of(2020, 9, 5))
@@ -282,13 +287,5 @@ class BookServiceTest {
         CustomShelf customShelf = customShelfService.createCustomShelf("My Shelf");
         customShelfService.save(customShelf);
         return customShelf;
-    }
-
-    private Set<Tag> createAndSaveTags() {
-        Tag tag1 = new Tag("book");
-        Tag tag2 = new Tag("adventure");
-        tagService.save(tag1);
-        tagService.save(tag2);
-        return new HashSet<Tag>(Arrays.asList(tag1, tag2));
     }
 }

--- a/backend/src/test/java/com/karankumar/bookproject/backend/util/PredefinedShelfUtilsTest.java
+++ b/backend/src/test/java/com/karankumar/bookproject/backend/util/PredefinedShelfUtilsTest.java
@@ -144,7 +144,7 @@ class PredefinedShelfUtilsTest {
         Set<Book> actualBooks = predefinedShelfService.getBooksInChosenPredefinedShelf(shelf);
 
         // then
-        assertThat(actualBooks.toString()).isEqualTo(expectedBooks.toString());
+        assertThat(actualBooks.toString()).hasToString(expectedBooks.toString());
     }
 
     @Test

--- a/backend/src/test/resources/exportedBooksSample.json
+++ b/backend/src/test/resources/exportedBooksSample.json
@@ -29,7 +29,9 @@
       "title": "Another Book Name",
       "numberOfPages": 420,
       "pagesRead": 42,
-      "bookGenre": "ADVENTURE",
+      "bookGenre": [
+        "ADVENTURE"
+      ],
       "bookFormat": "PAPERBACK",
       "seriesPosition": 3,
       "edition": "2nd edition",


### PR DESCRIPTION
## Summary of change

- Ignore Hibernate lazy initialiser on properties with a lazy fetch type
- Set genre to be a JSON array in the actual exported books sample

## Related issue

Closes #639 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.

If in doubt, get in touch with us by creating a [Q&A discussion](https://github.com/Project-Books/book-project/discussions/categories/q-a) on GitHub or ask on the #help channel in our Slack workspace
