### PR TITLE
Only save a UserCreatedShelf if its name is not taken 698

### DIFF
--- a/backend/src/main/java/com/karankumar/bookproject/backend/repository/UserCreatedShelfRepository.java
+++ b/backend/src/main/java/com/karankumar/bookproject/backend/repository/UserCreatedShelfRepository.java
@@ -22,6 +22,8 @@ import com.karankumar.bookproject.backend.model.UserCreatedShelf;
 import com.karankumar.bookproject.backend.model.account.User;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -42,4 +44,11 @@ public interface UserCreatedShelfRepository extends JpaRepository<UserCreatedShe
 
     @EntityGraph(value = "CustomShelf.books")
     List<UserCreatedShelf> findAll();
+
+    @Query("SELECT " +
+            "CASE WHEN COUNT(s) > 0 THEN TRUE " +
+            "ELSE FALSE END " +
+            "FROM UserCreatedShelf s " +
+            "WHERE LOWER(TRIM(s.shelfName)) LIKE LOWER(TRIM(:shelfName))")
+    boolean shelfNameExists(@Param("shelfName") String shelfName);
 }

--- a/backend/src/main/java/com/karankumar/bookproject/backend/service/UserCreatedShelfService.java
+++ b/backend/src/main/java/com/karankumar/bookproject/backend/service/UserCreatedShelfService.java
@@ -62,7 +62,10 @@ public class UserCreatedShelfService {
 
     public UserCreatedShelf save(@NonNull UserCreatedShelf userCreatedShelf) {
         if (shelfNameExists(userCreatedShelf.getShelfName())) {
-            throw new IllegalArgumentException(String.format("Given shelfName %s already exists", userCreatedShelf.getShelfName()));
+            throw new IllegalArgumentException(
+                    String.format("Given shelfName %s already exists",
+                            userCreatedShelf.getShelfName())
+            );
         }
         return userCreatedShelfRepository.save(userCreatedShelf);
     }

--- a/backend/src/main/java/com/karankumar/bookproject/backend/service/UserCreatedShelfService.java
+++ b/backend/src/main/java/com/karankumar/bookproject/backend/service/UserCreatedShelfService.java
@@ -18,8 +18,8 @@
 package com.karankumar.bookproject.backend.service;
 
 import com.karankumar.bookproject.backend.model.Book;
-import com.karankumar.bookproject.backend.model.UserCreatedShelf;
 import com.karankumar.bookproject.backend.model.Shelf;
+import com.karankumar.bookproject.backend.model.UserCreatedShelf;
 import com.karankumar.bookproject.backend.repository.UserCreatedShelfRepository;
 import lombok.NonNull;
 import lombok.extern.java.Log;
@@ -60,8 +60,10 @@ public class UserCreatedShelfService {
         return userCreatedShelfRepository.findByShelfNameAndUser(shelfName, userService.getCurrentUser());
     }
 
-    // TODO: only save custom shelf if the shelf name does not match the name of an existing (including predefined) shelf
     public UserCreatedShelf save(@NonNull UserCreatedShelf userCreatedShelf) {
+        if (shelfNameExists(userCreatedShelf.getShelfName())) {
+            throw new IllegalArgumentException(String.format("Given shelfName %s already exists", userCreatedShelf.getShelfName()));
+        }
         return userCreatedShelfRepository.save(userCreatedShelf);
     }
 
@@ -118,5 +120,13 @@ public class UserCreatedShelfService {
         Assert.hasText(shelfName, "Shelf Name cannot be empty");
         return findByShelfNameAndLoggedInUser(shelfName)
         		.orElseGet(() -> save(createCustomShelf(shelfName)));
+    }
+
+    private boolean shelfNameExists(String shelfName) {
+        if (PredefinedShelfService.isPredefinedShelf(shelfName.trim())) {
+            return true;
+        }
+
+        return userCreatedShelfRepository.shelfNameExists(shelfName);
     }
 }

--- a/backend/src/test/java/com/karankumar/bookproject/backend/repository/UserCreatedShelfRepositoryTest.java
+++ b/backend/src/test/java/com/karankumar/bookproject/backend/repository/UserCreatedShelfRepositoryTest.java
@@ -114,7 +114,6 @@ class UserCreatedShelfRepositoryTest {
     @ParameterizedTest
     @MethodSource("provideExistingUserCreatedShelfNames")
     void returnTrueWhenUserCreatedShelfNameExists(String existingShelfName) {
-        // when/then
         assertThat(repository.shelfNameExists(existingShelfName)).isTrue();
     }
 
@@ -129,7 +128,6 @@ class UserCreatedShelfRepositoryTest {
 
     @Test
     void returnFalseWhenUserCreatedShelfNameNotExists() {
-        // when/then
         assertThat(repository.shelfNameExists("NotExistingShelfName")).isFalse();
     }
 

--- a/backend/src/test/java/com/karankumar/bookproject/backend/repository/UserCreatedShelfRepositoryTest.java
+++ b/backend/src/test/java/com/karankumar/bookproject/backend/repository/UserCreatedShelfRepositoryTest.java
@@ -20,9 +20,13 @@ package com.karankumar.bookproject.backend.repository;
 import com.karankumar.bookproject.annotations.DataJpaIntegrationTest;
 import com.karankumar.bookproject.backend.model.UserCreatedShelf;
 import com.karankumar.bookproject.backend.model.account.User;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
@@ -33,6 +37,7 @@ import java.util.stream.Stream;
 import static com.karankumar.bookproject.util.SecurityTestUtils.getTestUser;
 import static com.karankumar.bookproject.util.SecurityTestUtils.insertTestUser;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @DataJpaIntegrationTest
@@ -106,6 +111,28 @@ class UserCreatedShelfRepositoryTest {
 
         // then
         assertThat(shelves).isNotNull().isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideExistingUserCreatedShelfNames")
+    void returnTrueWhenUserCreatedShelfNameExists(String existingShelfName) {
+        // when/then
+        Assertions.assertTrue(repository.shelfNameExists(existingShelfName));
+    }
+
+    private static Stream<Arguments> provideExistingUserCreatedShelfNames() {
+        return Stream.of(
+                Arguments.of("Test1"),
+                Arguments.of("TEST1"),
+                Arguments.of("test1"),
+                Arguments.of("  test1   ")
+        );
+    }
+
+    @Test
+    void returnFalseWhenUserCreatedShelfNameNotExists() {
+        // when/then
+        Assertions.assertFalse(repository.shelfNameExists("NotExistingShelfName"));
     }
 
     private void createShelvesForUser(User user) {

--- a/backend/src/test/java/com/karankumar/bookproject/backend/repository/UserCreatedShelfRepositoryTest.java
+++ b/backend/src/test/java/com/karankumar/bookproject/backend/repository/UserCreatedShelfRepositoryTest.java
@@ -20,7 +20,6 @@ package com.karankumar.bookproject.backend.repository;
 import com.karankumar.bookproject.annotations.DataJpaIntegrationTest;
 import com.karankumar.bookproject.backend.model.UserCreatedShelf;
 import com.karankumar.bookproject.backend.model.account.User;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,6 @@ import java.util.stream.Stream;
 import static com.karankumar.bookproject.util.SecurityTestUtils.getTestUser;
 import static com.karankumar.bookproject.util.SecurityTestUtils.insertTestUser;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @DataJpaIntegrationTest
@@ -117,7 +115,7 @@ class UserCreatedShelfRepositoryTest {
     @MethodSource("provideExistingUserCreatedShelfNames")
     void returnTrueWhenUserCreatedShelfNameExists(String existingShelfName) {
         // when/then
-        Assertions.assertTrue(repository.shelfNameExists(existingShelfName));
+        assertThat(repository.shelfNameExists(existingShelfName)).isTrue();
     }
 
     private static Stream<Arguments> provideExistingUserCreatedShelfNames() {
@@ -132,7 +130,7 @@ class UserCreatedShelfRepositoryTest {
     @Test
     void returnFalseWhenUserCreatedShelfNameNotExists() {
         // when/then
-        Assertions.assertFalse(repository.shelfNameExists("NotExistingShelfName"));
+        assertThat(repository.shelfNameExists("NotExistingShelfName")).isFalse();
     }
 
     private void createShelvesForUser(User user) {

--- a/backend/src/test/java/com/karankumar/bookproject/backend/service/UserCreatedShelfServiceTest.java
+++ b/backend/src/test/java/com/karankumar/bookproject/backend/service/UserCreatedShelfServiceTest.java
@@ -91,9 +91,11 @@ class UserCreatedShelfServiceTest {
 
     @ParameterizedTest
     @EnumSource(PredefinedShelfName.class)
-    void save_shouldThrowException_whenNameExistsInPredefinedShelfNames(PredefinedShelfName predefinedShelfName) {
+    void save_throws_whenNameExistsInPredefinedShelfNames(PredefinedShelfName predefinedShelfName) {
         // given
-        UserCreatedShelf createdShelf = new UserCreatedShelf(predefinedShelfName.toString(), User.builder().build());
+        UserCreatedShelf createdShelf = new UserCreatedShelf(
+                predefinedShelfName.toString(), User.builder().build()
+        );
 
         // when/then
         assertThatExceptionOfType(IllegalArgumentException.class)
@@ -102,10 +104,12 @@ class UserCreatedShelfServiceTest {
 
     @ParameterizedTest
     @EnumSource(PredefinedShelfName.class)
-    void save_shouldThrowException_whenNameExistsInPredefinedShelfNames_andContainsWhiteSpaces(PredefinedShelfName predefinedShelfName) {
+    void save_throws_whenNameExistsInPredefinedShelfNames_andContainsWhiteSpaces(PredefinedShelfName predefinedShelfName) {
         // given
         UserCreatedShelf createdShelf = new UserCreatedShelf(
-                "\t\n\f\r" + predefinedShelfName.toString() + "\t\n\f\r", User.builder().build());
+                "\t\n\f\r" + predefinedShelfName.toString() + "\t\n\f\r",
+                User.builder().build()
+        );
 
         // when/then
         assertThatExceptionOfType(IllegalArgumentException.class)
@@ -113,10 +117,13 @@ class UserCreatedShelfServiceTest {
     }
 
     @Test
-    void save_shouldThrowException_whenUserCreatedShelfNameAlreadyExists() {
+    void save_throws_whenUserCreatedShelfNameAlreadyExists() {
         // given
-        UserCreatedShelf createdShelf = new UserCreatedShelf("ExistingName", User.builder().build());
-        when(userCreatedShelfRepository.shelfNameExists("ExistingName")).thenReturn(true);
+        UserCreatedShelf createdShelf = new UserCreatedShelf(
+                "ExistingName",
+                User.builder().build()
+        );
+        when(userCreatedShelfRepository.shelfNameExists(anyString())).thenReturn(true);
 
         // when/then
         assertThatExceptionOfType(IllegalArgumentException.class)
@@ -126,8 +133,11 @@ class UserCreatedShelfServiceTest {
     @Test
     void save_whenUserCreatedShelfNameNotExists() {
         // given
-        UserCreatedShelf createdShelf = new UserCreatedShelf("NotExistingName", User.builder().build());
-        when(userCreatedShelfRepository.shelfNameExists("NotExistingName")).thenReturn(true);
+        UserCreatedShelf createdShelf = new UserCreatedShelf(
+                "NotExistingName",
+                User.builder().build()
+        );
+        when(userCreatedShelfRepository.shelfNameExists(anyString())).thenReturn(true);
 
         // when/then
         assertThatExceptionOfType(IllegalArgumentException.class)

--- a/backend/src/test/java/com/karankumar/bookproject/backend/service/UserCreatedShelfServiceTest.java
+++ b/backend/src/test/java/com/karankumar/bookproject/backend/service/UserCreatedShelfServiceTest.java
@@ -17,6 +17,7 @@
 
 package com.karankumar.bookproject.backend.service;
 
+import com.karankumar.bookproject.backend.model.PredefinedShelfName;
 import com.karankumar.bookproject.backend.model.UserCreatedShelf;
 import com.karankumar.bookproject.backend.model.account.User;
 import com.karankumar.bookproject.backend.repository.UserCreatedShelfRepository;
@@ -24,6 +25,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -36,6 +39,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UserCreatedShelfServiceTest {
@@ -83,6 +87,51 @@ class UserCreatedShelfServiceTest {
         assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> userCreatedShelfService.save(null));
         verify(userCreatedShelfRepository, never()).save(any(UserCreatedShelf.class));
+    }
+
+    @ParameterizedTest
+    @EnumSource(PredefinedShelfName.class)
+    void save_shouldThrowException_whenNameExistsInPredefinedShelfNames(PredefinedShelfName predefinedShelfName) {
+        // given
+        UserCreatedShelf createdShelf = new UserCreatedShelf(predefinedShelfName.toString(), User.builder().build());
+
+        // when/then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> userCreatedShelfService.save(createdShelf));
+    }
+
+    @ParameterizedTest
+    @EnumSource(PredefinedShelfName.class)
+    void save_shouldThrowException_whenNameExistsInPredefinedShelfNames_andContainsWhiteSpaces(PredefinedShelfName predefinedShelfName) {
+        // given
+        UserCreatedShelf createdShelf = new UserCreatedShelf(
+                "\t\n\f\r" + predefinedShelfName.toString() + "\t\n\f\r", User.builder().build());
+
+        // when/then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> userCreatedShelfService.save(createdShelf));
+    }
+
+    @Test
+    void save_shouldThrowException_whenUserCreatedShelfNameAlreadyExists() {
+        // given
+        UserCreatedShelf createdShelf = new UserCreatedShelf("ExistingName", User.builder().build());
+        when(userCreatedShelfRepository.shelfNameExists("ExistingName")).thenReturn(true);
+
+        // when/then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> userCreatedShelfService.save(createdShelf));
+    }
+
+    @Test
+    void save_whenUserCreatedShelfNameNotExists() {
+        // given
+        UserCreatedShelf createdShelf = new UserCreatedShelf("NotExistingName", User.builder().build());
+        when(userCreatedShelfRepository.shelfNameExists("NotExistingName")).thenReturn(true);
+
+        // when/then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> userCreatedShelfService.save(createdShelf));
     }
 
     @Test


### PR DESCRIPTION
## Summary of change

Resolves issue 698 by adding `UserCreatedShelf.shelfNameExists(String shelfName)` that validates shelfName before `userCreatedShelfRepository.save(userCreatedShelf)`. It prevents shelf duplication within `UserCreatedShelf` and `PredefinedShelf` entities.

## Related issue

Closes #698

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.
