### PR TITLE
750 - Display text for 500 server error

### DIFF
--- a/backend/src/main/java/com/karankumar/bookproject/backend/controller/UserController.java
+++ b/backend/src/main/java/com/karankumar/bookproject/backend/controller/UserController.java
@@ -19,7 +19,6 @@ import com.karankumar.bookproject.backend.dto.UserToRegisterDto;
 import com.karankumar.bookproject.backend.model.account.User;
 import com.karankumar.bookproject.backend.service.UserAlreadyRegisteredException;
 import com.karankumar.bookproject.backend.service.UserService;
-import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -69,13 +68,11 @@ public class UserController {
                           );
     }
 
-    @SneakyThrows
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public void register(@RequestBody UserToRegisterDto user) {
         try {
-            throw new Exception();
-//            userService.register(user);
+            userService.register(user);
         } catch (UserAlreadyRegisteredException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Email taken");
         }

--- a/backend/src/main/java/com/karankumar/bookproject/backend/controller/UserController.java
+++ b/backend/src/main/java/com/karankumar/bookproject/backend/controller/UserController.java
@@ -19,6 +19,7 @@ import com.karankumar.bookproject.backend.dto.UserToRegisterDto;
 import com.karankumar.bookproject.backend.model.account.User;
 import com.karankumar.bookproject.backend.service.UserAlreadyRegisteredException;
 import com.karankumar.bookproject.backend.service.UserService;
+import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -68,11 +69,13 @@ public class UserController {
                           );
     }
 
+    @SneakyThrows
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public void register(@RequestBody UserToRegisterDto user) {
         try {
-            userService.register(user);
+            throw new Exception();
+//            userService.register(user);
         } catch (UserAlreadyRegisteredException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Email taken");
         }

--- a/frontend/src/register/Register.tsx
+++ b/frontend/src/register/Register.tsx
@@ -129,7 +129,7 @@ class Register extends Component<Record<string, unknown>, IState> {
 
         fetch(Endpoints.user, requestOptions)
             .then(response => {
-                if(response.status === 500){
+                if (response.status === 500) {
                     this.setState({serverError:true})
                 }
                 return response.json()
@@ -149,7 +149,7 @@ class Register extends Component<Record<string, unknown>, IState> {
     }
 
     // function to display server error
-    renderServerError(): ReactElement{
+    renderServerError(): ReactElement {
         return (
             <p className="error-message">
               Something went wrong. Please try again later.

--- a/frontend/src/register/Register.tsx
+++ b/frontend/src/register/Register.tsx
@@ -46,7 +46,8 @@ interface IState {
     isEmailDirty: boolean,
     isPasswordDirty: boolean,
     isEmailInvalid: boolean,
-    isPasswordInvalid: boolean
+    isPasswordInvalid: boolean,
+    serverError: boolean
 }
 
 class Register extends Component<Record<string, unknown>, IState> {
@@ -61,7 +62,8 @@ class Register extends Component<Record<string, unknown>, IState> {
             isEmailDirty: false,
             isPasswordDirty: false,
             isEmailInvalid: false,
-            isPasswordInvalid: false
+            isPasswordInvalid: false,
+            serverError: false
         }
 
         this.handlePasswordChanged = this.handlePasswordChanged.bind(this)
@@ -126,7 +128,12 @@ class Register extends Component<Record<string, unknown>, IState> {
         }
 
         fetch(Endpoints.user, requestOptions)
-            .then(response => response.json())
+            .then(response => {
+                if(response.status === 500){
+                    this.setState({serverError:true})
+                }
+                return response.json()
+            })
             .then(data => console.log('data: ', data))
             .catch(error => console.log('error: ', error))
     }
@@ -141,6 +148,15 @@ class Register extends Component<Record<string, unknown>, IState> {
         return isPasswordDirtyAndBlank || this.state.isPasswordInvalid
     }
 
+    // function to display server error
+    renderServerError(): ReactElement{
+        return (
+            <p className="error-message">
+              Something went wrong. Please try again later.
+            </p>
+     )
+ }  
+
     render(): ReactElement {
         return (
             <div className="center-table">
@@ -148,7 +164,7 @@ class Register extends Component<Record<string, unknown>, IState> {
                     <img src={logo} alt="Logo" className="center" id="app-logo" />
 
                     <br />
-                    <br />
+                    <br />                
                     <br />
 
                     <div className="center">
@@ -207,6 +223,8 @@ class Register extends Component<Record<string, unknown>, IState> {
                           >
                             Sign in instead
                         </Button>
+                        
+                        {this.state.serverError ? this.renderServerError(): <br></br>}   
 
                     </div>
                 </div>


### PR DESCRIPTION
## Summary of change
Added text display for 500 server error when attempting to create new account.

- function renderServerError() returns error message if 500 server error is found

## Additional context

![image](https://user-images.githubusercontent.com/55907638/134189100-012dc571-1e5a-4697-85cf-79327a9c5b84.png)

## Related issue

Closes #750 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.
