### PR TITLE
Make view switcher sticky

### DIFF
--- a/frontend/src/my-books/MyBooks.css
+++ b/frontend/src/my-books/MyBooks.css
@@ -26,6 +26,8 @@ If not, see <https://www.gnu.org/licenses/>.
   flex-direction: row;
   justify-content: flex-end;
   padding-bottom: 40px;
+  position: sticky;
+  bottom: 0;
 }
 
 .my-book-toggle-text {

--- a/frontend/src/my-books/MyBooks.css
+++ b/frontend/src/my-books/MyBooks.css
@@ -25,7 +25,9 @@ If not, see <https://www.gnu.org/licenses/>.
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  padding-bottom: 40px;
+  padding: 20px 0;
+  background: rgb(255,255,255);
+  background: linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 45%);
   position: sticky;
   bottom: 0;
 }


### PR DESCRIPTION
## Summary of change

Changed some CSS to make the shelf view toggle on `My Books` sticky. This is in line with the Figma mockups.

## Additional context

This is what it looks like now:
![image](https://user-images.githubusercontent.com/23417273/135484180-c8f1b528-516a-4946-bc93-c85e512d96a2.png)


## Related issue

Closes #765 

## Pull request checklist



- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.
