### PR TITLE
Specify the version of asciidoctor and override default ascii config with project specific

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -20,6 +20,7 @@
         <lombok.version>1.18.20</lombok.version>
         <sonar.organization>project-books</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <asciidoctor.maven.plugin.version>2.2.1</asciidoctor.maven.plugin.version>
     </properties>
 
     <dependencies>
@@ -250,6 +251,16 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>${asciidoctor.maven.plugin.version}</version>
+                <configuration>
+                    <sourceDirectory>${basedir}/src/main/asciidoc</sourceDirectory>
+                    <sourceDocumentName>index.adoc</sourceDocumentName>
+                    <outputDirectory>${project.build.directory}/docs</outputDirectory>
+                    <backend>html</backend>
+                    <attributes>
+                        <snippets>${project.build.directory}/snippets</snippets>
+                    </attributes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>generate-docs</id>
@@ -257,13 +268,6 @@
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>
-                        <configuration>
-                            <sourceDocumentName>index.adoc</sourceDocumentName>
-                            <backend>html</backend>
-                            <attributes>
-                                <snippets>${project.build.directory}/snippets</snippets>
-                            </attributes>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Override default configuration of asciidoctor with project specific paths.

## Summary of change

Moved the configuration section of the plugin so that it overrides the default configuration to project specific paths.
Add maven property that points to the version of the asciidoctor plugin.
Add the version tag for the asciidoctor plugin.

## Related issue

Closes #756 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.
