### PR TITLE
Updating deprecated parser() method, will now use parserBuilder()

### DIFF
--- a/backend/src/main/java/com/karankumar/bookproject/backend/security/jwt/JwtTokenVerifier.java
+++ b/backend/src/main/java/com/karankumar/bookproject/backend/security/jwt/JwtTokenVerifier.java
@@ -62,8 +62,9 @@ public class JwtTokenVerifier extends OncePerRequestFilter {
 
         String token = authorizationHeader.replace(tokenPrefix ,"");
         try {
-            Jws<Claims> claimsJws = Jwts.parser()
+            Jws<Claims> claimsJws = Jwts.parserBuilder()
                                         .setSigningKey(secretKey)
+                                        .build()
                                         .parseClaimsJws(token);
             Claims body = claimsJws.getBody();
             String username = body.getSubject();


### PR DESCRIPTION
I have updated a deprecated method inside JwtTokenVerifier.java - parser() it should now use parserBuilder() and .build()

Updated as per official guidelines.

Closes #802

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.
