### PR TITLE
build: only run frontend jobs based on file patterns

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -1,7 +1,19 @@
 name: Frontend Lint
 on:
   push:
+    paths:
+      - 'frontend/**/*.jsx?'
+      - 'frontend/**/*.tsx?'
+      - 'frontend/**/*.html'
+      - 'frontend/**/*.json'
+      - 'frontend/**/*.css'
   pull_request:
+    paths:
+      - 'frontend/**/*.jsx?'
+      - 'frontend/**/*.tsx?'
+      - 'frontend/**/*.html'
+      - 'frontend/**/*.json'
+      - 'frontend/**/*.css'
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary of change
Configure frontend workflow to run only when at least one file match paths during push and pull requests.
With this changes you can see that the front end workflow will not execute since there are no file changes that meet the criteria in #821 

## Related issue

Closes #821

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.
