### PR TITLE
add pagination to get all books endpoint #839

### DIFF
--- a/backend/book-app/src/main/java/com/karankumar/bookproject/repository/BookRepository.java
+++ b/backend/book-app/src/main/java/com/karankumar/bookproject/repository/BookRepository.java
@@ -19,6 +19,7 @@ package com.karankumar.bookproject.repository;
 
 import com.karankumar.bookproject.model.Book;
 import com.karankumar.bookproject.model.PredefinedShelf.ShelfName;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -28,51 +29,51 @@ import java.util.List;
 import java.util.Optional;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
-    @EntityGraph(value = "Book.author", type = EntityGraph.EntityGraphType.LOAD)
-    @Query("SELECT b " +
-            "FROM Book b " +
-            "INNER JOIN FETCH b.author " +
-            "INNER JOIN FETCH b.predefinedShelf " +
-            "INNER JOIN FETCH b.tags " +
-            "INNER JOIN FETCH b.publishers" )
-    List<Book> findAllBooks();
+  @EntityGraph(value = "Book.author", type = EntityGraph.EntityGraphType.LOAD)
+  @Query("SELECT b " +
+    "FROM Book b " +
+    "INNER JOIN FETCH b.author " +
+    "INNER JOIN FETCH b.predefinedShelf " +
+    "INNER JOIN FETCH b.tags " +
+    "INNER JOIN FETCH b.publishers")
+  List<Book> findAllBooks(Pageable pageable);
 
-    @EntityGraph(value = "Book.author", type = EntityGraph.EntityGraphType.LOAD)
-    List<Book> findAll();
+  @EntityGraph(value = "Book.author", type = EntityGraph.EntityGraphType.LOAD)
+  List<Book> findAll();
 
-
-    @EntityGraph(value = "Book.author", type = EntityGraph.EntityGraphType.LOAD)
-    @Query("SELECT b " +
-            "FROM Book b " +
-            "INNER JOIN FETCH b.author " +
-            "INNER JOIN FETCH b.predefinedShelf " +
-            "INNER JOIN FETCH b.tags " +
-            "INNER JOIN FETCH b.publishers " +
-            "WHERE b.id = :id" )
-    Optional<Book> findBookById(@Param("id") Long id);
-
-    @EntityGraph(value = "Book.author", type = EntityGraph.EntityGraphType.LOAD)
-    List<Book> findByTitleContainingIgnoreCase(String title);
-
-    @EntityGraph(value = "Book.author", type = EntityGraph.EntityGraphType.LOAD)
-    @Query("SELECT b " +
-            "FROM Book b " +
-            "INNER JOIN FETCH b.author AS a " +
-            "INNER JOIN FETCH b.predefinedShelf " +
-            "INNER JOIN FETCH b.tags " +
-            "INNER JOIN FETCH b.publishers " +
-            "WHERE LOWER(b.title) LIKE LOWER(CONCAT('%', :titleOrAuthor, '%')) OR " +
-                "LOWER(a.fullName) LIKE LOWER(CONCAT('%', :titleOrAuthor, '%'))")
-    List<Book> findByTitleOrAuthor(@Param("titleOrAuthor") String titleOrAuthor);
 
   @EntityGraph(value = "Book.author", type = EntityGraph.EntityGraphType.LOAD)
   @Query("SELECT b " +
-      "FROM Book b " +
-      "INNER JOIN FETCH b.author " +
-      "INNER JOIN FETCH b.predefinedShelf s " +
-      "INNER JOIN FETCH b.tags " +
-      "INNER JOIN FETCH b.publishers " +
-      "WHERE s.predefinedShelfName = :predefinedShelfName")
+    "FROM Book b " +
+    "INNER JOIN FETCH b.author " +
+    "INNER JOIN FETCH b.predefinedShelf " +
+    "INNER JOIN FETCH b.tags " +
+    "INNER JOIN FETCH b.publishers " +
+    "WHERE b.id = :id")
+  Optional<Book> findBookById(@Param("id") Long id);
+
+  @EntityGraph(value = "Book.author", type = EntityGraph.EntityGraphType.LOAD)
+  List<Book> findByTitleContainingIgnoreCase(String title);
+
+  @EntityGraph(value = "Book.author", type = EntityGraph.EntityGraphType.LOAD)
+  @Query("SELECT b " +
+    "FROM Book b " +
+    "INNER JOIN FETCH b.author AS a " +
+    "INNER JOIN FETCH b.predefinedShelf " +
+    "INNER JOIN FETCH b.tags " +
+    "INNER JOIN FETCH b.publishers " +
+    "WHERE LOWER(b.title) LIKE LOWER(CONCAT('%', :titleOrAuthor, '%')) OR " +
+    "LOWER(a.fullName) LIKE LOWER(CONCAT('%', :titleOrAuthor, '%'))")
+  List<Book> findByTitleOrAuthor(@Param("titleOrAuthor") String titleOrAuthor);
+
+  @EntityGraph(value = "Book.author", type = EntityGraph.EntityGraphType.LOAD)
+  @Query("SELECT b " +
+    "FROM Book b " +
+    "INNER JOIN FETCH b.author " +
+    "INNER JOIN FETCH b.predefinedShelf s " +
+    "INNER JOIN FETCH b.tags " +
+    "INNER JOIN FETCH b.publishers " +
+    "WHERE s.predefinedShelfName = :predefinedShelfName")
   List<Book> findAllBooksByPredefinedShelfShelfName(
-      @Param("predefinedShelfName") ShelfName predefinedShelfName);
+    @Param("predefinedShelfName") ShelfName predefinedShelfName);
 }

--- a/backend/book-app/src/main/java/com/karankumar/bookproject/service/BookService.java
+++ b/backend/book-app/src/main/java/com/karankumar/bookproject/service/BookService.java
@@ -33,6 +33,8 @@ import com.karankumar.bookproject.repository.BookRepository;
 import lombok.NonNull;
 import lombok.extern.java.Log;
 import org.apache.commons.lang3.NotImplementedException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,7 +56,7 @@ public class BookService {
   private final PredefinedShelfService predefinedShelfService;
 
   public BookService(BookRepository bookRepository, AuthorService authorService,
-      PublisherService publisherService, PredefinedShelfService predefinedShelfService) {
+                     PublisherService publisherService, PredefinedShelfService predefinedShelfService) {
     this.bookRepository = bookRepository;
     this.authorService = authorService;
     this.publisherService = publisherService;
@@ -101,13 +103,15 @@ public class BookService {
     return bookRepository.count();
   }
 
-  public List<Book> findAll() {
-    return bookRepository.findAllBooks();
+  public List<Book> findAll(Integer pageNumber) {
+    int page = pageNumber == null ? 0 : pageNumber;
+    Pageable pageable = PageRequest.of(page, 50);
+    return bookRepository.findAllBooks(pageable);
   }
 
   public List<Book> findAll(String filterText) {
     if (filterText == null || filterText.isEmpty()) {
-      return findAll();
+      return findAll(0);
     }
     return bookRepository.findByTitleContainingIgnoreCase(filterText);
   }
@@ -130,13 +134,13 @@ public class BookService {
 
   public void deleteAll() {
     LOGGER.log(Level.INFO, "Deleting all in books & authors. Book repository size = " +
-        bookRepository.count());
+      bookRepository.count());
     bookRepository.deleteAll();
     authorService.deleteAll();
 
     LOGGER.log(
-        Level.INFO, "Deleted all books in books & authors. Book repository size = " +
-            bookRepository.count()
+      Level.INFO, "Deleted all books in books & authors. Book repository size = " +
+        bookRepository.count()
     );
   }
 
@@ -177,47 +181,47 @@ public class BookService {
 
   private void updateBookMetadata(Book book, BookPatchDto bookPatchDto) {
     Optional.ofNullable(bookPatchDto.getTitle())
-        .ifPresent(book::setTitle);
+      .ifPresent(book::setTitle);
     Optional.ofNullable(bookPatchDto.getNumberOfPages())
-        .ifPresent(book::setNumberOfPages);
+      .ifPresent(book::setNumberOfPages);
     Optional.ofNullable(bookPatchDto.getPagesRead())
-        .ifPresent(book::setPagesRead);
+      .ifPresent(book::setPagesRead);
     Optional.ofNullable(bookPatchDto.getBookFormat())
-        .map(BookFormat::valueOf)
-        .ifPresent(book::setBookFormat);
+      .map(BookFormat::valueOf)
+      .ifPresent(book::setBookFormat);
     Optional.ofNullable(bookPatchDto.getSeriesPosition())
-        .ifPresent(book::setSeriesPosition);
+      .ifPresent(book::setSeriesPosition);
     Optional.ofNullable(bookPatchDto.getEdition())
-        .ifPresent(book::setEdition);
+      .ifPresent(book::setEdition);
     Optional.ofNullable(bookPatchDto.getBookRecommendedBy())
-        .ifPresent(book::setBookRecommendedBy);
+      .ifPresent(book::setBookRecommendedBy);
     Optional.ofNullable(bookPatchDto.getIsbn())
-        .ifPresent(book::setIsbn);
+      .ifPresent(book::setIsbn);
     Optional.ofNullable(bookPatchDto.getYearOfPublication())
-        .ifPresent(book::setYearOfPublication);
+      .ifPresent(book::setYearOfPublication);
     Optional.ofNullable(bookPatchDto.getBookReview())
-        .ifPresent(book::setBookReview);
+      .ifPresent(book::setBookReview);
   }
 
   private void updateAuthor(Book book, BookPatchDto bookPatchDto) {
     Optional.ofNullable(bookPatchDto.getAuthor())
-        .ifPresent(author -> {
-          book.setAuthor(author);
-          authorService.save(book.getAuthor());
-        });
+      .ifPresent(author -> {
+        book.setAuthor(author);
+        authorService.save(book.getAuthor());
+      });
   }
 
   private void updateGenres(Book book, BookPatchDto bookPatchDto) {
     Optional.ofNullable(bookPatchDto.getBookGenres())
-        .map(genres -> genres.stream().map(BookGenre::valueOf).collect(toSet()))
-        .ifPresent(book::setBookGenre);
+      .map(genres -> genres.stream().map(BookGenre::valueOf).collect(toSet()))
+      .ifPresent(book::setBookGenre);
   }
 
   private void updatePredefinedShelf(Book book, BookPatchDto bookPatchDto) {
     Optional.ofNullable(bookPatchDto.getPredefinedShelf())
-        .map(ShelfName::valueOf)
-        .flatMap(predefinedShelfService::getPredefinedShelfByPredefinedShelfName)
-        .ifPresent(book::setPredefinedShelf);
+      .map(ShelfName::valueOf)
+      .flatMap(predefinedShelfService::getPredefinedShelfByPredefinedShelfName)
+      .ifPresent(book::setPredefinedShelf);
   }
 
 }

--- a/backend/book-app/src/test/java/com/karankumar/bookproject/controller/BookControllerTest.java
+++ b/backend/book-app/src/test/java/com/karankumar/bookproject/controller/BookControllerTest.java
@@ -15,7 +15,6 @@
 package com.karankumar.bookproject.controller;
 
 import com.karankumar.bookproject.model.Book;
-import com.karankumar.bookproject.model.Shelf;
 import com.karankumar.bookproject.service.BookService;
 import com.karankumar.bookproject.service.PredefinedShelfService;
 import org.junit.jupiter.api.Test;
@@ -34,62 +33,78 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class BookControllerTest {
-    private final BookController bookController;
-    private final BookService mockedBookService;
+  private final BookController bookController;
+  private final BookService mockedBookService;
 
-    BookControllerTest() {
-        mockedBookService = mock(BookService.class);
-        PredefinedShelfService mockedPredefinedShelfService = mock(PredefinedShelfService.class);
-        ModelMapper mockedModelMapper = mock(ModelMapper.class);
-        bookController = new BookController(
-                mockedBookService,
-                mockedPredefinedShelfService,
-                mockedModelMapper
-        );
-    }
+  BookControllerTest() {
+    mockedBookService = mock(BookService.class);
+    PredefinedShelfService mockedPredefinedShelfService = mock(PredefinedShelfService.class);
+    ModelMapper mockedModelMapper = mock(ModelMapper.class);
+    bookController = new BookController(
+      mockedBookService,
+      mockedPredefinedShelfService,
+      mockedModelMapper
+    );
+  }
 
-    @Test
-    void all_returnsEmptyList_whenNoBooksExist() {
-        when(mockedBookService.findAll()).thenReturn(new ArrayList<>());
+  @Test
+  void all_returnsEmptyList_whenNoBooksExist() {
+    int page = 0;
+    when(mockedBookService.findAll(page)).thenReturn(new ArrayList<>());
 
-        assertThat(bookController.all().size()).isZero();
-    }
+    assertThat(bookController.all(page).size()).isZero();
+  }
 
-    @Test
-    void all_returnsNonEmptyList_whenBooksExist() {
-        // given
-        List<Book> books = new ArrayList<>();
-        books.add(new Book());
-        books.add(new Book());
+  @Test
+  void all_returnsBadRequest_whenNegativePage() {
+    Integer page = -1;
+    String expectedMessage = String.format(
+      "%s \"%s\"",
+      HttpStatus.BAD_REQUEST,
+      String.format(BookController.NEGATIVE_PAGE_ERROR_MESSAGE, page)
+    );
 
-        // when
-        when(mockedBookService.findAll()).thenReturn(books);
+    assertThatExceptionOfType(ResponseStatusException.class)
+      .isThrownBy(() -> bookController.all(page))
+      .withMessage(expectedMessage);
+  }
 
-        // then
-        assertThat(bookController.all().size()).isEqualTo(books.size());
-    }
+  @Test
+  void all_returnsNonEmptyList_whenBooksExist() {
+    // given
+    int page = 0;
+    List<Book> books = new ArrayList<>();
+    books.add(new Book());
+    books.add(new Book());
 
-    @Test
-    void findById_returnsBook_ifPresent() {
-        Book book = new Book();
-        when(mockedBookService.findById(any(Long.class)))
-                .thenReturn(Optional.of(book));
+    // when
+    when(mockedBookService.findAll(page)).thenReturn(books);
 
-        assertThat(bookController.findById(0L)).isEqualTo(book);
-    }
+    // then
+    assertThat(bookController.all(page).size()).isEqualTo(books.size());
+  }
 
-    @Test
-    void findById_returnsNotFound_ifBookIsEmpty() {
-        when(mockedBookService.findById(any(Long.class)))
-                .thenReturn(Optional.empty());
+  @Test
+  void findById_returnsBook_ifPresent() {
+    Book book = new Book();
+    when(mockedBookService.findById(any(Long.class)))
+      .thenReturn(Optional.of(book));
 
-        assertThatExceptionOfType(ResponseStatusException.class)
-                .isThrownBy(() -> bookController.findById(0L));
-    }
+    assertThat(bookController.findById(0L)).isEqualTo(book);
+  }
 
-    @Test
+  @Test
+  void findById_returnsNotFound_ifBookIsEmpty() {
+    when(mockedBookService.findById(any(Long.class)))
+      .thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResponseStatusException.class)
+      .isThrownBy(() -> bookController.findById(0L));
+  }
+
+  @Test
     // TODO: finish writing this test
-    void findByShelf_returnsNotFound_ifBookDoesNotExist() {
+  void findByShelf_returnsNotFound_ifBookDoesNotExist() {
 //        when(mockedBookService.findByShelfAndTitleOrAuthor(
 //                any(Shelf.class),
 //                any(String.class),
@@ -98,15 +113,15 @@ class BookControllerTest {
 
 //        assertThatExceptionOfType(BookNotFoundException.class)
 //                .isThrownBy(bookController.findByShelf(new CustomShelf(), "title", "author"));
-    }
+  }
 
-    @Test
+  @Test
     // TODO: finish writing this test
-    void delete_returnsNotFound_ifBookDoesNotExist() {
-        when(mockedBookService.findById(any(Long.class)))
-                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND));
+  void delete_returnsNotFound_ifBookDoesNotExist() {
+    when(mockedBookService.findById(any(Long.class)))
+      .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND));
 
 //        assertThatExceptionOfType(BookNotFoundException.class)
 //                .isThrownBy(bookController.delete(1L));
-    }
+  }
 }

--- a/backend/book-app/src/test/java/com/karankumar/bookproject/service/BookServiceTest.java
+++ b/backend/book-app/src/test/java/com/karankumar/bookproject/service/BookServiceTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -42,128 +43,130 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class BookServiceTest {
-    @Mock private BookRepository bookRepository;
-    private BookService bookService;
+  @Mock
+  private BookRepository bookRepository;
+  private BookService bookService;
 
-    @BeforeEach
-    public void setUp() {
-        AuthorService authorService = mock(AuthorService.class);
-        PublisherService publisherService = mock(PublisherService.class);
-        PredefinedShelfService predefinedShelfService = mock(PredefinedShelfService.class);
-        bookService = new BookService(bookRepository, authorService, publisherService, predefinedShelfService);
-    }
+  @BeforeEach
+  public void setUp() {
+    AuthorService authorService = mock(AuthorService.class);
+    PublisherService publisherService = mock(PublisherService.class);
+    PredefinedShelfService predefinedShelfService = mock(PredefinedShelfService.class);
+    bookService = new BookService(bookRepository, authorService, publisherService, predefinedShelfService);
+  }
 
-    @Test
-    void findById_throwsException_ifIdIsNull() {
-        assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> bookService.findById(null));
-        verify(bookRepository, never()).findById(anyLong());
-    }
+  @Test
+  void findById_throwsException_ifIdIsNull() {
+    assertThatExceptionOfType(NullPointerException.class)
+      .isThrownBy(() -> bookService.findById(null));
+    verify(bookRepository, never()).findById(anyLong());
+  }
 
-    @Test
-    void canFindByNonNullId() {
-        bookService.findById(1L);
-        verify(bookRepository).findBookById(anyLong());
-    }
+  @Test
+  void canFindByNonNullId() {
+    bookService.findById(1L);
+    verify(bookRepository).findBookById(anyLong());
+  }
 
-    @Test
-    void save_throwsException_ifBookIsNull() {
-        assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> bookService.save(null));
-        verify(bookRepository, never()).save(any(Book.class));
-    }
+  @Test
+  void save_throwsException_ifBookIsNull() {
+    assertThatExceptionOfType(NullPointerException.class)
+      .isThrownBy(() -> bookService.save(null));
+    verify(bookRepository, never()).save(any(Book.class));
+  }
 
-    @Test
-    void save_returnsEmpty_ifBookDoesNotHaveAuthor() {
-        // given
-        User user = User.builder().build();
-        PredefinedShelf predefinedShelf = new PredefinedShelf(PredefinedShelf.ShelfName.READ, user);
-        Book book = new Book(
-                "title",
-                null,
-                predefinedShelf
-        );
+  @Test
+  void save_returnsEmpty_ifBookDoesNotHaveAuthor() {
+    // given
+    User user = User.builder().build();
+    PredefinedShelf predefinedShelf = new PredefinedShelf(PredefinedShelf.ShelfName.READ, user);
+    Book book = new Book(
+      "title",
+      null,
+      predefinedShelf
+    );
 
-        // when
-        Optional<Book> actual = bookService.save(book);
+    // when
+    Optional<Book> actual = bookService.save(book);
 
-        // then
-        assertThat(actual).isEmpty();
-        verify(bookRepository, never()).save(book);
-    }
+    // then
+    assertThat(actual).isEmpty();
+    verify(bookRepository, never()).save(book);
+  }
 
-    @Test
-    // TODO: fix test
-    @Disabled
-    void canSaveIfBookHasAuthorAndPredefinedShelf() {
-        // given
-        User user = User.builder().build();
-        PredefinedShelf predefinedShelf = new PredefinedShelf(PredefinedShelf.ShelfName.READ, user);
-        Book book = new Book(
-                "title",
-                new Author("test"),
-                predefinedShelf
-        );
+  @Test
+  // TODO: fix test
+  @Disabled
+  void canSaveIfBookHasAuthorAndPredefinedShelf() {
+    // given
+    User user = User.builder().build();
+    PredefinedShelf predefinedShelf = new PredefinedShelf(PredefinedShelf.ShelfName.READ, user);
+    Book book = new Book(
+      "title",
+      new Author("test"),
+      predefinedShelf
+    );
 
-        // when
-        Optional<Book> actual = bookService.save(book);
+    // when
+    Optional<Book> actual = bookService.save(book);
 
-        // then
-        assertThat(actual).isNotEmpty();
+    // then
+    assertThat(actual).isNotEmpty();
 
-        ArgumentCaptor<Book> bookArgumentCaptor = ArgumentCaptor.forClass(Book.class);
-        verify(bookRepository).save(bookArgumentCaptor.capture());
-        Book capturedBook = bookArgumentCaptor.capture();
-        assertThat(capturedBook).isEqualTo(book);
-    }
+    ArgumentCaptor<Book> bookArgumentCaptor = ArgumentCaptor.forClass(Book.class);
+    verify(bookRepository).save(bookArgumentCaptor.capture());
+    Book capturedBook = bookArgumentCaptor.capture();
+    assertThat(capturedBook).isEqualTo(book);
+  }
 
-    @Test
-    void canCount() {
-        bookService.count();
-        verify(bookRepository).count();
-    }
+  @Test
+  void canCount() {
+    bookService.count();
+    verify(bookRepository).count();
+  }
 
-    @Test
-    void canFindAll() {
-        bookService.findAll();
-        verify(bookRepository).findAllBooks();
-    }
+  @Test
+  void canFindAll() {
+    int page = 0;
+    bookService.findAll(page);
+    verify(bookRepository).findAllBooks(any(Pageable.class));
+  }
 
-    @Test
-    void findAll_searchesWithoutFilter_ifFilterIsNull() {
-        bookService.findAll(null);
-        verify(bookRepository).findAllBooks();
-    }
+  @Test
+  void findAll_searchesWithoutFilter_ifFilterIsNull() {
+    bookService.findAll((String) null);
+    verify(bookRepository).findAllBooks(any(Pageable.class));
+  }
 
-    @Test
-    void findAll_searchesWithoutFilter_ifFilterIsEmpty() {
-        bookService.findAll("");
-        verify(bookRepository).findAllBooks();
-    }
+  @Test
+  void findAll_searchesWithoutFilter_ifFilterIsEmpty() {
+    bookService.findAll("");
+    verify(bookRepository).findAllBooks(any(Pageable.class));
+  }
 
-    @Test
-    void findAll_filtersByTitle_ifFilterIsNotNullOrEmpty() {
-        // given
-        String filter = "test";
+  @Test
+  void findAll_filtersByTitle_ifFilterIsNotNullOrEmpty() {
+    // given
+    String filter = "test";
 
-        // when
-        bookService.findAll(filter);
+    // when
+    bookService.findAll(filter);
 
-        // then
-        verify(bookRepository).findByTitleContainingIgnoreCase(filter);
-    }
+    // then
+    verify(bookRepository).findByTitleContainingIgnoreCase(filter);
+  }
 
-    @Test
-    void delete_throwsException_ifBookIsNull() {
-        assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> bookService.delete(null));
-    }
+  @Test
+  void delete_throwsException_ifBookIsNull() {
+    assertThatExceptionOfType(NullPointerException.class)
+      .isThrownBy(() -> bookService.delete(null));
+  }
 
-    @Test
-    void canDeleteAll() {
-        bookService.deleteAll();
-        verify(bookRepository).deleteAll();
-    }
+  @Test
+  void canDeleteAll() {
+    bookService.deleteAll();
+    verify(bookRepository).deleteAll();
+  }
 
 //    @Test
 //    void canFindByTitleOrAuthor() {


### PR DESCRIPTION
## Summary of change

I have added an optional request parameter on the get all books endpoint which represents the page being requested.
The service returns 50 results per page.

## Additional context
I installed the google plugin for reformatting but I had very little luck in managing to now have unnecessary additions and deletions, but they're mostly blank spaces, I apologize for this, I think the source code is mixed too so unless I completely disable it I can't find the right setting.

## Related issue

Closes #839 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.
