### PR TITLE
Fix docs links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-See [Code of Conduct](https://project-books.github.io/docs/code-of-conduct/)
+See [Code of Conduct](https://project-books.github.io/conduct/code-of-conduct/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See our [contributing document](https://project-books.github.io/docs/development/contributing/).
+See our [contributing document](https://project-books.github.io/development/contributing/).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ When running the frontend and backend, or only the backend, you can use the foll
 - Email address: `user@user.user`
 - Password: `password`
 
-Note: If you're running the backend, you will need a JWT token for subsequent requests after logging in or creating an account; see our [connecting to the backend](https://project-books.github.io/docs/development/how-to/backend-postman/) wiki page.
+Note: If you're running the backend, you will need a JWT token for subsequent requests after logging in or creating an account; see our [connecting to the backend](https://project-books.github.io/development/how-to/backend-postman/) wiki page.
  
 ## Access database (optional)
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -4,10 +4,10 @@ By contributing to this repository, you are expected to follow our style guides.
 
 ## Frontend
 
-[TypeScript style guide](https://project-books.github.io/docs/development/styleguides/typescript-styleguide/)
+[TypeScript style guide](https://project-books.github.io/development/styleguides/typescript-styleguide/)
 
-[React style guide](https://project-books.github.io/docs/development/styleguides/react-styleguide/)
+[React style guide](https://project-books.github.io/development/styleguides/react-styleguide/)
 
 ## Backend
 
-[Java style guide](https://project-books.github.io/docs/development/styleguides/java-styleguide/)
+[Java style guide](https://project-books.github.io/development/styleguides/java-styleguide/)


### PR DESCRIPTION
## Summary of change

Fix links to documentation

## Additional context

Fixed links :
- Code of conduct (from CODE_OF_CONDUCT.md)
- Contributing (from CONTRIBUTING.md)
- Code Style (from STYLEGUIDE.md)
- Backend postman (from README.md)

## Related issue

Open #935

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.

Link to CONTRIBUTE.md from README.md (line 71) doesn't work well in fix-docs-link branch.
After merge to main branch, it will be solved as CONTRIBUTE.md's url changes from "/fix-docs-link/" to "~/main/"